### PR TITLE
peer handling: friendlier error message on invalid address, more RPC output, introduce peer state concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6014,6 +6014,7 @@ dependencies = [
  "bitcoin",
  "jsonrpsee",
  "l2l-openapi",
+ "serde",
  "serde_json",
  "thunder",
  "utoipa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5945,6 +5945,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
  "thiserror 2.0.11",
  "tiny-bip39",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = "0.12.1"
 prost = "0.13.3"
 serde = "1.0.179"
 serde_json = "1.0.113"
+strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "2.0.11"
 tiny-bip39 = "2.0.0"
 tokio = { version = "1.29.1", default-features = false, features = ["signal"] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -22,7 +22,7 @@ poll-promise = { version = "0.3.0", features = ["tokio"] }
 rustreexo = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 shlex = "1.3.0"
-strum = { version = "0.26.2", features = ["derive"] }
+strum = { workspace = true }
 thiserror = { workspace = true }
 thunder = { path = "../lib" }
 thunder_app_cli = { path = "../cli" }

--- a/app/rpc_server.rs
+++ b/app/rpc_server.rs
@@ -7,10 +7,11 @@ use jsonrpsee::{
     types::ErrorObject,
 };
 use thunder::{
+    net::peer::Peer,
     types::{Address, PointedOutput, Txid, WithdrawalBundle},
     wallet::Balance,
 };
-use thunder_app_rpc_api::{schema::Peer as RpcPeer, RpcServer};
+use thunder_app_rpc_api::RpcServer;
 
 use crate::app::App;
 
@@ -138,14 +139,11 @@ impl RpcServer for RpcServerImpl {
         Ok(height)
     }
 
-    async fn list_peers(&self) -> RpcResult<Vec<RpcPeer>> {
+    async fn list_peers(&self) -> RpcResult<Vec<Peer>> {
         let peers = self.app.node.get_active_peers();
         let res: Vec<_> = peers
             .into_iter()
-            .map(|(address, state)| RpcPeer {
-                address: address.to_string(),
-                state: state.to_string(),
-            })
+            .map(|(address, state)| Peer { address, state })
             .collect();
         Ok(res)
     }

--- a/app/rpc_server.rs
+++ b/app/rpc_server.rs
@@ -10,7 +10,7 @@ use thunder::{
     types::{Address, PointedOutput, Txid, WithdrawalBundle},
     wallet::Balance,
 };
-use thunder_app_rpc_api::RpcServer;
+use thunder_app_rpc_api::{schema::Peer as RpcPeer, RpcServer};
 
 use crate::app::App;
 
@@ -138,9 +138,16 @@ impl RpcServer for RpcServerImpl {
         Ok(height)
     }
 
-    async fn list_peers(&self) -> RpcResult<Vec<SocketAddr>> {
+    async fn list_peers(&self) -> RpcResult<Vec<RpcPeer>> {
         let peers = self.app.node.get_active_peers();
-        Ok(peers)
+        let res: Vec<_> = peers
+            .into_iter()
+            .map(|(address, state)| RpcPeer {
+                address: address.to_string(),
+                state: state.to_string(),
+            })
+            .collect();
+        Ok(res)
     }
 
     async fn list_utxos(&self) -> RpcResult<Vec<PointedOutput>> {

--- a/app/rpc_server.rs
+++ b/app/rpc_server.rs
@@ -7,7 +7,7 @@ use jsonrpsee::{
     types::ErrorObject,
 };
 use thunder::{
-    net::peer::Peer,
+    net::Peer,
     types::{Address, PointedOutput, Txid, WithdrawalBundle},
     wallet::Balance,
 };
@@ -141,11 +141,7 @@ impl RpcServer for RpcServerImpl {
 
     async fn list_peers(&self) -> RpcResult<Vec<Peer>> {
         let peers = self.app.node.get_active_peers();
-        let res: Vec<_> = peers
-            .into_iter()
-            .map(|(address, state)| Peer { address, state })
-            .collect();
-        Ok(res)
+        Ok(peers)
     }
 
     async fn list_utxos(&self) -> RpcResult<Vec<PointedOutput>> {

--- a/integration_tests/ibd.rs
+++ b/integration_tests/ibd.rs
@@ -83,10 +83,10 @@ async fn check_peer_connection(
         .list_peers()
         .await?
         .iter()
-        .map(|p| p.address.to_string())
+        .map(|p| p.address)
         .collect::<Vec<_>>();
 
-    if peers.contains(&expected_peer.to_string()) {
+    if peers.contains(&expected_peer) {
         Ok(())
     } else {
         Err(anyhow::anyhow!(

--- a/integration_tests/ibd.rs
+++ b/integration_tests/ibd.rs
@@ -78,8 +78,15 @@ async fn check_peer_connection(
     thunder_setup: &PostSetup,
     expected_peer: SocketAddr,
 ) -> anyhow::Result<()> {
-    let peers = thunder_setup.rpc_client.list_peers().await?;
-    if peers.contains(&expected_peer) {
+    let peers = thunder_setup
+        .rpc_client
+        .list_peers()
+        .await?
+        .iter()
+        .map(|p| p.address.to_string())
+        .collect::<Vec<_>>();
+
+    if peers.contains(&expected_peer.to_string()) {
         Ok(())
     } else {
         Err(anyhow::anyhow!(

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -41,6 +41,7 @@ semver = { version = "1.0.25", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { version = "3.4.0" }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map, HashMap, HashSet},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     sync::Arc,
 };
 
@@ -12,7 +12,6 @@ use heed::{
 };
 use parking_lot::RwLock;
 use quinn::{ClientConfig, Endpoint, ServerConfig};
-use strum;
 use tokio_stream::StreamNotifyClose;
 use tracing::instrument;
 
@@ -22,7 +21,7 @@ use crate::{
     types::{AuthorizedTransaction, THIS_SIDECHAIN},
 };
 
-pub mod peer;
+mod peer;
 
 use peer::{
     Connection, ConnectionContext as PeerConnectionCtxt,
@@ -30,8 +29,8 @@ use peer::{
 };
 pub use peer::{
     ConnectionError as PeerConnectionError, Info as PeerConnectionInfo,
-    InternalMessage as PeerConnectionMessage, PeerStateId,
-    Request as PeerRequest, Response as PeerResponse,
+    InternalMessage as PeerConnectionMessage, Peer, PeerConnectionStatus,
+    PeerStateId, Request as PeerRequest, Response as PeerResponse,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -60,8 +59,8 @@ pub enum Error {
     PeerNotConnected(SocketAddr),
     /// Unspecified peer IP addresses cannot be connected to.
     /// `0.0.0.0` is one example of an "unspecified" IP.
-    #[error("unspecified peer ip address (cannot connect to '0.0.0.0')")]
-    UnspecfiedPeerIP,
+    #[error("unspecified peer ip address (cannot connect to '{0}')")]
+    UnspecfiedPeerIP(IpAddr),
     #[error(transparent)]
     NoInitialCipherSuite(#[from] quinn::crypto::rustls::NoInitialCipherSuite),
     #[error("peer connection")]
@@ -193,30 +192,9 @@ pub fn make_server_endpoint(
     Ok((endpoint, server_cert))
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Eq,
-    PartialEq,
-    serde::Serialize,
-    serde::Deserialize,
-    strum::Display,
-    utoipa::ToSchema,
-)]
-pub enum PeerConnectionState {
-    /// We're still in the process of initializing the peer connection
-    Connecting,
-
-    /// The connection is successfully established
-    Connected,
-}
-
 // None indicates that the stream has ended
 pub type PeerInfoRx =
     mpsc::UnboundedReceiver<(SocketAddr, Option<PeerConnectionInfo>)>;
-
-// State.
-// Archive.
 
 // Keep track of peer state
 // Exchange metadata
@@ -233,11 +211,7 @@ pub struct Net {
     pub server: Endpoint,
     archive: Archive,
     state: State,
-    active_peers: Arc<
-        RwLock<
-            HashMap<SocketAddr, (PeerConnectionHandle, PeerConnectionState)>,
-        >,
-    >,
+    active_peers: Arc<RwLock<HashMap<SocketAddr, PeerConnectionHandle>>>,
     // None indicates that the stream has ended
     peer_info_tx:
         mpsc::UnboundedSender<(SocketAddr, Option<PeerConnectionInfo>)>,
@@ -247,26 +221,12 @@ pub struct Net {
 impl Net {
     pub const NUM_DBS: u32 = 1;
 
-    fn update_active_peer_state(
-        &self,
-        addr: SocketAddr,
-        new_state: PeerConnectionState,
-    ) -> Result<(), Error> {
-        let mut active_peers_write = self.active_peers.write();
-        active_peers_write
-            .entry(addr)
-            .and_modify(|(_, state)| *state = new_state);
-        Ok(())
-    }
-
     fn add_active_peer(
         &self,
         addr: SocketAddr,
         peer_connection_handle: PeerConnectionHandle,
-        state: PeerConnectionState,
     ) -> Result<(), Error> {
         tracing::trace!(%addr, "add active peer: starting");
-
         let mut active_peers_write = self.active_peers.write();
         match active_peers_write.entry(addr) {
             hash_map::Entry::Occupied(_) => {
@@ -274,7 +234,7 @@ impl Net {
                 Err(Error::AlreadyConnected(addr))
             }
             hash_map::Entry::Vacant(active_peer_entry) => {
-                active_peer_entry.insert((peer_connection_handle, state));
+                active_peer_entry.insert(peer_connection_handle);
                 Ok(())
             }
         }
@@ -289,12 +249,16 @@ impl Net {
         }
     }
 
-    // TODO: This should have more context. Last received message, connection state, etc.
-    pub fn get_active_peers(&self) -> Vec<(SocketAddr, PeerConnectionState)> {
+    // TODO: This should have more context.
+    // Last received message, connection state, etc.
+    pub fn get_active_peers(&self) -> Vec<Peer> {
         self.active_peers
             .read()
             .iter()
-            .map(|(addr, (_, state))| (*addr, state.to_owned()))
+            .map(|(addr, conn_handle)| Peer {
+                address: *addr,
+                status: conn_handle.connection_status(),
+            })
             .collect()
     }
 
@@ -314,7 +278,7 @@ impl Net {
         // same check, and provide a friendlier error
         // message.
         if addr.ip().is_unspecified() {
-            return Err(Error::UnspecfiedPeerIP);
+            return Err(Error::UnspecfiedPeerIP(addr.ip()));
         }
         let connecting = self.server.connect(addr, "localhost")?;
         let mut rwtxn = env.write_txn()?;
@@ -326,49 +290,22 @@ impl Net {
             state: self.state.clone(),
         };
 
-        let (connected_tx, mut connected_rx) = mpsc::unbounded();
         let (connection_handle, info_rx) =
-            peer::connect(connecting, connection_ctxt, connected_tx);
+            peer::connect(connecting, connection_ctxt);
         tracing::trace!("connect peer: spawning info rx");
         tokio::spawn({
             let info_rx = StreamNotifyClose::new(info_rx)
                 .map(move |info| Ok((addr, info)));
             let peer_info_tx = self.peer_info_tx.clone();
-            let net = self.clone();
-
             async move {
-                let update_peer_state = async move {
-                    connected_rx.next().await.inspect(|_| {
-                        match net.update_active_peer_state(addr, PeerConnectionState::Connected) {
-                            Ok(_) => {
-                                tracing::info!(%addr, "connect peer: updated state to connected");
-                            }
-                            Err(err) => {
-                                tracing::error!(
-                                    "failed to update active peer state: {err:#}"
-                                );
-                            }
-                        }
-                    })
-                };
-
-                let forward_peer_info = async move {
-                    if let Err(_send_err) = info_rx.forward(peer_info_tx).await
-                    {
-                        tracing::error!("Failed to send peer connection info");
-                    };
-                };
-
-                tokio::join!(forward_peer_info, update_peer_state)
+                if let Err(_send_err) = info_rx.forward(peer_info_tx).await {
+                    tracing::error!(%addr, "Failed to send peer connection info");
+                }
             }
         });
 
         tracing::trace!("connect peer: adding to active peers");
-        self.add_active_peer(
-            addr,
-            connection_handle,
-            PeerConnectionState::Connecting,
-        )?;
+        self.add_active_peer(addr, connection_handle)?;
         Ok(())
     }
 
@@ -517,11 +454,7 @@ impl Net {
             }
         });
         // TODO: is this the right state?
-        self.add_active_peer(
-            addr,
-            connection_handle,
-            PeerConnectionState::Connected,
-        )?;
+        self.add_active_peer(addr, connection_handle)?;
         Ok(Some(addr))
     }
 
@@ -532,17 +465,15 @@ impl Net {
         addr: SocketAddr,
     ) -> Result<(), Error> {
         let active_peers_read = self.active_peers.read();
-        let Some((peer_connection_handle, state)) =
-            active_peers_read.get(&addr)
-        else {
-            return Err(Error::MissingPeerConnection(addr));
-        };
+        let peer_connection_handle = active_peers_read
+            .get(&addr)
+            .ok_or_else(|| Error::MissingPeerConnection(addr))?;
 
-        match state {
-            PeerConnectionState::Connecting => {
+        match peer_connection_handle.connection_status() {
+            PeerConnectionStatus::Connecting => {
                 return Err(Error::PeerNotConnected(addr));
             }
-            PeerConnectionState::Connected => {}
+            PeerConnectionStatus::Connected => {}
         }
 
         if let Err(send_err) = peer_connection_handle
@@ -563,8 +494,7 @@ impl Net {
     ) {
         let active_peers_read = self.active_peers.read();
         for addr in peers {
-            let Some((peer_connection_handle, PeerConnectionState::Connected)) =
-                active_peers_read.get(addr)
+            let Some(peer_connection_handle) = active_peers_read.get(addr)
             else {
                 continue;
             };
@@ -589,13 +519,13 @@ impl Net {
             .read()
             .iter()
             .filter(|(addr, _)| !exclude.contains(addr))
-            .for_each(|(addr, (peer_connection_handle, state))| {
-                match state {
-                    PeerConnectionState::Connecting => {
+            .for_each(|(addr, peer_connection_handle)| {
+                match peer_connection_handle.connection_status() {
+                    PeerConnectionStatus::Connecting => {
                         tracing::trace!(%addr, "skipping peer at {addr} because it is not fully connected");
                         return;
                     }
-                    PeerConnectionState::Connected => {}
+                    PeerConnectionStatus::Connected => {}
                 }
                 let request = PeerRequest::PushTransaction {
                     transaction: tx.clone(),

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -298,7 +298,7 @@ impl Net {
             .collect()
     }
 
-    #[instrument(skip(self, env), err(Debug))]
+    #[instrument(skip_all, fields(addr), err(Debug))]
     pub fn connect_peer(
         &self,
         env: heed::Env,

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -486,29 +486,6 @@ impl Net {
         Ok(())
     }
 
-    // Push a request to the specified peers
-    pub fn push_request(
-        &self,
-        request: PeerRequest,
-        peers: &HashSet<SocketAddr>,
-    ) {
-        let active_peers_read = self.active_peers.read();
-        for addr in peers {
-            let Some(peer_connection_handle) = active_peers_read.get(addr)
-            else {
-                continue;
-            };
-            if let Err(_send_err) = peer_connection_handle
-                .internal_message_tx
-                .unbounded_send(request.clone().into())
-            {
-                tracing::warn!(
-                    "Failed to push request to peer at {addr}: {request:?}"
-                )
-            }
-        }
-    }
-
     /// Push a tx to all active peers, except those in the provided set
     pub fn push_tx(
         &self,

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -55,8 +55,6 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("peer connection not found for {0}")]
     MissingPeerConnection(SocketAddr),
-    #[error("peer connection is not fully connected for {0}")]
-    PeerNotConnected(SocketAddr),
     /// Unspecified peer IP addresses cannot be connected to.
     /// `0.0.0.0` is one example of an "unspecified" IP.
     #[error("unspecified peer ip address (cannot connect to '{0}')")]
@@ -468,13 +466,6 @@ impl Net {
         let peer_connection_handle = active_peers_read
             .get(&addr)
             .ok_or_else(|| Error::MissingPeerConnection(addr))?;
-
-        match peer_connection_handle.connection_status() {
-            PeerConnectionStatus::Connecting => {
-                return Err(Error::PeerNotConnected(addr));
-            }
-            PeerConnectionStatus::Connected => {}
-        }
 
         if let Err(send_err) = peer_connection_handle
             .internal_message_tx

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -339,17 +339,17 @@ impl Net {
             async move {
                 let update_peer_state = async move {
                     connected_rx.next().await.inspect(|_| {
-                    let _res = net
-                        .update_active_peer_state(addr, PeerConnectionState::Connected)
-                        .inspect(|_| {
-                            tracing::info!(%addr, "connect peer: updated state to connected");
-                        })
-                        .inspect_err(|err| {
-                            tracing::error!(
-                                "failed to update active peer state: {err:#}"
-                            );
-                        });
-                })
+                        match net.update_active_peer_state(addr, PeerConnectionState::Connected) {
+                            Ok(_) => {
+                                tracing::info!(%addr, "connect peer: updated state to connected");
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    "failed to update active peer state: {err:#}"
+                                );
+                            }
+                        }
+                    })
                 };
 
                 let forward_peer_info = async move {

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -179,10 +179,7 @@ pub fn make_server_endpoint(
 ) -> Result<(Endpoint, Vec<u8>), Error> {
     let (server_config, server_cert) = configure_server()?;
 
-    tracing::info!(
-        "creating server endpoint: binding to {bind_addr} ({})",
-        if bind_addr.is_ipv6() { "ipv6" } else { "ipv4" }
-    );
+    tracing::info!("creating server endpoint: binding to {bind_addr}",);
 
     let mut endpoint = Endpoint::server(server_config, bind_addr)?;
     let client_cfg = configure_client()?;

--- a/lib/net/peer.rs
+++ b/lib/net/peer.rs
@@ -20,10 +20,11 @@ use tokio_stream::wrappers::IntervalStream;
 
 use crate::{
     archive::{self, Archive},
+    net::PeerConnectionState,
     state::{self, State},
     types::{
-        hash, proto::mainchain, AuthorizedTransaction, BlockHash, BmmResult,
-        Body, Hash, Header, Tip, Txid, Version, VERSION,
+        hash, proto::mainchain, schema, AuthorizedTransaction, BlockHash,
+        BmmResult, Body, Hash, Header, Tip, Txid, Version, VERSION,
     },
 };
 
@@ -1338,4 +1339,16 @@ pub fn connect(
         internal_message_tx,
     };
     (connection_handle, info_rx)
+}
+
+// RPC output representation for peer + state
+// TODO: use better types here. Struggling with how to satisfy utoipa
+
+#[derive(Clone, serde::Deserialize, serde::Serialize, utoipa:: ToSchema)]
+pub struct Peer {
+    #[schema(value_type = schema::SocketAddr)]
+    pub address: SocketAddr,
+
+    #[schema(value_type = schema::PeerConnectionState)]
+    pub state: PeerConnectionState,
 }

--- a/lib/net/peer.rs
+++ b/lib/net/peer.rs
@@ -2,6 +2,10 @@ use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
     net::SocketAddr,
+    sync::{
+        atomic::{self, AtomicBool},
+        Arc,
+    },
 };
 
 use bitcoin::Work;
@@ -20,7 +24,6 @@ use tokio_stream::wrappers::IntervalStream;
 
 use crate::{
     archive::{self, Archive},
-    net::PeerConnectionState,
     state::{self, State},
     types::{
         hash, proto::mainchain, schema, AuthorizedTransaction, BlockHash,
@@ -1245,11 +1248,58 @@ impl ConnectionTask {
     }
 }
 
+#[derive(
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    utoipa::ToSchema,
+)]
+pub enum PeerConnectionStatus {
+    /// We're still in the process of initializing the peer connection
+    Connecting,
+    /// The connection is successfully established
+    Connected,
+}
+
+impl PeerConnectionStatus {
+    /// Convert from boolean representation
+    // Should remain private to this module
+    fn from_repr(repr: bool) -> Self {
+        match repr {
+            false => Self::Connecting,
+            true => Self::Connected,
+        }
+    }
+
+    /// Convert to boolean representation
+    // Should remain private to this module
+    fn as_repr(self) -> bool {
+        match self {
+            Self::Connecting => false,
+            Self::Connected => true,
+        }
+    }
+}
+
 /// Connection killed on drop
 pub struct ConnectionHandle {
     task: JoinHandle<()>,
+    /// Representation of [`PeerConnectionStatus`]
+    pub(in crate::net) status_repr: Arc<AtomicBool>,
     /// Push messages from connection task / net task / node
     pub internal_message_tx: mpsc::UnboundedSender<InternalMessage>,
+}
+
+impl ConnectionHandle {
+    pub fn connection_status(&self) -> PeerConnectionStatus {
+        PeerConnectionStatus::from_repr(
+            self.status_repr.load(atomic::Ordering::SeqCst),
+        )
+    }
 }
 
 impl Drop for ConnectionHandle {
@@ -1292,8 +1342,10 @@ pub fn handle(
             }
         }
     });
+    let status = PeerConnectionStatus::Connected;
     let connection_handle = ConnectionHandle {
         task,
+        status_repr: Arc::new(AtomicBool::new(status.as_repr())),
         internal_message_tx,
     };
     (connection_handle, info_rx)
@@ -1302,18 +1354,21 @@ pub fn handle(
 pub fn connect(
     connecting: quinn::Connecting,
     ctxt: ConnectionContext,
-    on_connected: mpsc::UnboundedSender<()>,
 ) -> (ConnectionHandle, mpsc::UnboundedReceiver<Info>) {
+    let connection_status = PeerConnectionStatus::Connecting;
+    let status_repr = Arc::new(AtomicBool::new(connection_status.as_repr()));
     let (internal_message_tx, internal_message_rx) = mpsc::unbounded();
     let (info_tx, info_rx) = mpsc::unbounded();
     let connection_task = {
+        let status_repr = status_repr.clone();
         let info_tx = info_tx.clone();
         let internal_message_tx = internal_message_tx.clone();
         move || async move {
             let connection = Connection::new(connecting).await?;
-            if let Err(send_error) = on_connected.unbounded_send(()) {
-                tracing::error!("Failed to send on_connected: {send_error:#}");
-            }
+            status_repr.store(
+                PeerConnectionStatus::Connected.as_repr(),
+                atomic::Ordering::SeqCst,
+            );
 
             let connection_task = ConnectionTask {
                 connection,
@@ -1336,19 +1391,16 @@ pub fn connect(
     });
     let connection_handle = ConnectionHandle {
         task,
+        status_repr,
         internal_message_tx,
     };
     (connection_handle, info_rx)
 }
 
 // RPC output representation for peer + state
-// TODO: use better types here. Struggling with how to satisfy utoipa
-
-#[derive(Clone, serde::Deserialize, serde::Serialize, utoipa:: ToSchema)]
+#[derive(Clone, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct Peer {
     #[schema(value_type = schema::SocketAddr)]
     pub address: SocketAddr,
-
-    #[schema(value_type = schema::PeerConnectionState)]
-    pub state: PeerConnectionState,
+    pub status: PeerConnectionStatus,
 }

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -17,7 +17,7 @@ use tonic::transport::Channel;
 use crate::{
     archive::{self, Archive},
     mempool::{self, MemPool},
-    net::{self, Net},
+    net::{self, Net, PeerConnectionState},
     state::{self, State},
     types::{
         proto::{self, mainchain},
@@ -485,7 +485,7 @@ where
             .map_err(Error::from)
     }
 
-    pub fn get_active_peers(&self) -> Vec<(SocketAddr, net::PeerState)> {
+    pub fn get_active_peers(&self) -> Vec<(SocketAddr, PeerConnectionState)> {
         self.net.get_active_peers()
     }
 

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -17,7 +17,7 @@ use tonic::transport::Channel;
 use crate::{
     archive::{self, Archive},
     mempool::{self, MemPool},
-    net::{self, Net, PeerConnectionState},
+    net::{self, Net, Peer},
     state::{self, State},
     types::{
         proto::{self, mainchain},
@@ -485,7 +485,7 @@ where
             .map_err(Error::from)
     }
 
-    pub fn get_active_peers(&self) -> Vec<(SocketAddr, PeerConnectionState)> {
+    pub fn get_active_peers(&self) -> Vec<Peer> {
         self.net.get_active_peers()
     }
 

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -485,7 +485,7 @@ where
             .map_err(Error::from)
     }
 
-    pub fn get_active_peers(&self) -> Vec<SocketAddr> {
+    pub fn get_active_peers(&self) -> Vec<(SocketAddr, net::PeerState)> {
         self.net.get_active_peers()
     }
 

--- a/lib/types/schema.rs
+++ b/lib/types/schema.rs
@@ -94,3 +94,33 @@ impl ToSchema for UtreexoProof {
         std::borrow::Cow::Borrowed("utreexo.Proof")
     }
 }
+
+pub struct SocketAddr;
+
+impl PartialSchema for SocketAddr {
+    fn schema() -> RefOr<Schema> {
+        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
+        RefOr::T(Schema::Object(obj))
+    }
+}
+
+impl ToSchema for SocketAddr {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("net.SocketAddr")
+    }
+}
+
+pub struct PeerConnectionState;
+
+impl PartialSchema for PeerConnectionState {
+    fn schema() -> RefOr<Schema> {
+        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
+        RefOr::T(Schema::Object(obj))
+    }
+}
+
+impl ToSchema for PeerConnectionState {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("net.PeerConnectionState")
+    }
+}

--- a/rpc-api/Cargo.toml
+++ b/rpc-api/Cargo.toml
@@ -13,6 +13,7 @@ l2l-openapi = { workspace = true }
 thunder = { path = "../lib" }
 serde_json = { workspace = true }
 utoipa = { workspace = true }
+serde.workspace = true
 
 [lints]
 workspace = true

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -12,7 +12,7 @@ use thunder::{
     wallet::Balance,
 };
 
-mod schema;
+pub mod schema;
 
 #[open_api(ref_schemas[
     Address, MerkleRoot, OutPoint, Output, OutputContent, Txid,
@@ -96,9 +96,9 @@ pub trait Rpc {
     ) -> RpcResult<Option<u32>>;
 
     /// List peers
-    #[open_api_method(output_schema(PartialSchema = "schema::SocketAddr"))]
+    #[open_api_method(output_schema(PartialSchema = "schema::Peer"))]
     #[method(name = "list_peers")]
-    async fn list_peers(&self) -> RpcResult<Vec<SocketAddr>>;
+    async fn list_peers(&self) -> RpcResult<Vec<schema::Peer>>;
 
     /// List all UTXOs
     #[method(name = "list_utxos")]

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use l2l_openapi::open_api;
 use thunder::{
-    net::peer::Peer,
+    net::Peer,
     types::{
         schema as thunder_schema, Address, MerkleRoot, OutPoint, Output,
         OutputContent, PointedOutput, Txid, WithdrawalBundle,

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use l2l_openapi::open_api;
 use thunder::{
+    net::peer::Peer,
     types::{
         schema as thunder_schema, Address, MerkleRoot, OutPoint, Output,
         OutputContent, PointedOutput, Txid, WithdrawalBundle,
@@ -98,7 +99,7 @@ pub trait Rpc {
     /// List peers
     #[open_api_method(output_schema(PartialSchema = "schema::Peer"))]
     #[method(name = "list_peers")]
-    async fn list_peers(&self) -> RpcResult<Vec<schema::Peer>>;
+    async fn list_peers(&self) -> RpcResult<Vec<Peer>>;
 
     /// List all UTXOs
     #[method(name = "list_utxos")]

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -13,7 +13,7 @@ use thunder::{
     wallet::Balance,
 };
 
-pub mod schema;
+mod schema;
 
 #[open_api(ref_schemas[
     Address, MerkleRoot, OutPoint, Output, OutputContent, Txid,
@@ -97,7 +97,6 @@ pub trait Rpc {
     ) -> RpcResult<Option<u32>>;
 
     /// List peers
-    #[open_api_method(output_schema(PartialSchema = "schema::Peer"))]
     #[method(name = "list_peers")]
     async fn list_peers(&self) -> RpcResult<Vec<Peer>>;
 

--- a/rpc-api/schema.rs
+++ b/rpc-api/schema.rs
@@ -1,6 +1,5 @@
 //! Schemas for OpenAPI
 
-use serde::{Deserialize, Serialize};
 use utoipa::{
     openapi::{self, RefOr, Schema},
     PartialSchema, ToSchema,
@@ -21,13 +20,19 @@ impl ToSchema for BitcoinTxid {
     }
 }
 
-// RPC output representation for peer + state
-// TODO: use better types here. Struggling with how to satisfy utoipa
+pub struct Peer;
 
-#[derive(Clone, Deserialize, Serialize, ToSchema)]
-pub struct Peer {
-    pub address: String,
-    pub state: String,
+impl PartialSchema for Peer {
+    fn schema() -> RefOr<Schema> {
+        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
+        RefOr::T(Schema::Object(obj))
+    }
+}
+
+impl ToSchema for Peer {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("net.Peer")
+    }
 }
 
 pub struct OpenApi;

--- a/rpc-api/schema.rs
+++ b/rpc-api/schema.rs
@@ -1,5 +1,6 @@
 //! Schemas for OpenAPI
 
+use serde::{Deserialize, Serialize};
 use utoipa::{
     openapi::{self, RefOr, Schema},
     PartialSchema, ToSchema,
@@ -18,6 +19,15 @@ impl ToSchema for BitcoinTxid {
     fn name() -> std::borrow::Cow<'static, str> {
         std::borrow::Cow::Borrowed("bitcoin.Txid")
     }
+}
+
+// RPC output representation for peer + state
+// TODO: use better types here. Struggling with how to satisfy utoipa
+
+#[derive(Clone, Deserialize, Serialize, ToSchema)]
+pub struct Peer {
+    pub address: String,
+    pub state: String,
 }
 
 pub struct OpenApi;

--- a/rpc-api/schema.rs
+++ b/rpc-api/schema.rs
@@ -20,21 +20,6 @@ impl ToSchema for BitcoinTxid {
     }
 }
 
-pub struct Peer;
-
-impl PartialSchema for Peer {
-    fn schema() -> RefOr<Schema> {
-        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
-        RefOr::T(Schema::Object(obj))
-    }
-}
-
-impl ToSchema for Peer {
-    fn name() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("net.Peer")
-    }
-}
-
 pub struct OpenApi;
 
 impl PartialSchema for OpenApi {


### PR DESCRIPTION
Closes #14 

In this PR we introduce a new `PeerState` enum. I'm not sure this is the ideal naming. There's already a similarly named struct in `net`. Open to suggestions!