### PR TITLE
multi: turn CLI rpc addr param into URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,6 +6005,7 @@ dependencies = [
  "thunder",
  "thunder_app_rpc_api",
  "tokio",
+ "url",
  "utoipa",
 ]
 

--- a/app/app.rs
+++ b/app/app.rs
@@ -199,11 +199,11 @@ impl App {
 
         tracing::info!(
             "Connecting to mainchain at {}",
-            config.mainchain_grpc_address
+            config.mainchain_grpc_url
         );
         let rt_guard = runtime.enter();
         let transport = tonic::transport::channel::Channel::from_shared(
-            format!("{}", config.mainchain_grpc_address),
+            format!("{}", config.mainchain_grpc_url),
         )
         .unwrap()
         .concurrency_limit(256)
@@ -212,7 +212,7 @@ impl App {
             .block_on(Self::check_proto_support(transport.clone()))
             .map_err(|err| {
                 Error::VerifyMainchainServices(
-                    config.mainchain_grpc_address.clone(),
+                    config.mainchain_grpc_url.clone(),
                     err,
                 )
             })? {

--- a/app/cli.rs
+++ b/app/cli.rs
@@ -118,9 +118,9 @@ pub(super) struct Cli {
     #[arg(default_value_t = tracing::Level::DEBUG, long)]
     log_level: tracing::Level,
 
-    /// Address (protocol + host + port) to connect to mainchain node gRPC server
+    /// Connect to mainchain node gRPC server running at this URL
     #[arg(default_value = "http://localhost:50051", long)]
-    mainchain_grpc_address: url::Url,
+    mainchain_grpc_url: url::Url,
 
     /// Path to a mnemonic seed phrase
     #[arg(long)]
@@ -141,7 +141,7 @@ pub struct Config {
     pub log_dir: Option<PathBuf>,
     pub log_level: tracing::Level,
     pub log_level_file: tracing::Level, // Level for logs that get written to file
-    pub mainchain_grpc_address: url::Url,
+    pub mainchain_grpc_url: url::Url,
     pub mnemonic_seed_phrase_path: Option<PathBuf>,
     pub net_addr: SocketAddr,
     pub rpc_addr: SocketAddr,
@@ -171,7 +171,7 @@ impl Cli {
             log_dir,
             log_level: self.log_level,
             log_level_file: self.log_level_file,
-            mainchain_grpc_address: self.mainchain_grpc_address,
+            mainchain_grpc_url: self.mainchain_grpc_url,
             mnemonic_seed_phrase_path: self.mnemonic_seed_phrase_path,
             net_addr: self.net_addr,
             rpc_addr: self.rpc_addr,

--- a/app/gui/console_logs.rs
+++ b/app/gui/console_logs.rs
@@ -1,9 +1,6 @@
-use std::{
-    net::SocketAddr,
-    sync::{
-        atomic::{self, AtomicBool},
-        Arc,
-    },
+use std::sync::{
+    atomic::{self, AtomicBool},
+    Arc,
 };
 
 use clap::Parser;
@@ -32,12 +29,12 @@ pub struct ConsoleCommand {
 pub struct ConsoleLogs {
     line_buffer: LineBuffer,
     command_input: String,
-    rpc_addr: SocketAddr,
+    rpc_addr: url::Url,
     running_command: Arc<AtomicBool>,
 }
 
 impl ConsoleLogs {
-    pub fn new(line_buffer: LineBuffer, rpc_addr: SocketAddr) -> Self {
+    pub fn new(line_buffer: LineBuffer, rpc_addr: url::Url) -> Self {
         Self {
             line_buffer,
             command_input: String::new(),
@@ -71,7 +68,7 @@ impl ConsoleLogs {
             }
         };
         let cli = thunder_app_cli_lib::Cli {
-            rpc_addr: self.rpc_addr,
+            rpc_url: self.rpc_addr.clone(),
             timeout: None,
             command,
         };

--- a/app/gui/mod.rs
+++ b/app/gui/mod.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, task::Poll};
+use std::task::Poll;
 
 use eframe::egui::{self, RichText};
 use strum::{EnumIter, IntoEnumIterator};
@@ -189,7 +189,7 @@ impl EguiApp {
         app: Option<App>,
         cc: &eframe::CreationContext<'_>,
         logs_capture: LineBuffer,
-        rpc_addr: SocketAddr,
+        rpc_addr: url::Url,
     ) -> Self {
         // Customize egui here with cc.egui_ctx.set_fonts and cc.egui_ctx.set_visuals.
         // Restore app state using cc.storage (requires the "persistence" feature).

--- a/app/main.rs
+++ b/app/main.rs
@@ -147,6 +147,8 @@ fn run_egui_app(
     app: Result<crate::app::App, crate::app::Error>,
 ) -> Result<(), eframe::Error> {
     let native_options = eframe::NativeOptions::default();
+    let rpc_addr = url::Url::parse(&format!("http://{}", config.rpc_addr))
+        .expect("failed to parse rpc addr");
     eframe::run_native(
         "Thunder",
         native_options,
@@ -155,7 +157,7 @@ fn run_egui_app(
                 app.ok(),
                 cc,
                 line_buffer,
-                config.rpc_addr,
+                rpc_addr,
             )))
         }),
     )

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { workspace = true }
 thunder = { path = "../lib" }
 thunder_app_rpc_api = { path = "../rpc-api" }
 tokio = { workspace = true }
+url = "2.5.4"
 utoipa = { workspace = true }
 
 [lints]

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -61,7 +61,7 @@ impl ThunderApp {
             "--datadir".to_owned(),
             self.data_dir.display().to_string(),
             "--headless".to_owned(),
-            "--mainchain-grpc-address".to_owned(),
+            "--mainchain-grpc-url".to_owned(),
             format!("http://127.0.0.1:{}", self.mainchain_grpc_port),
             "--net-addr".to_owned(),
             format!("127.0.0.1:{}", self.net_port),

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -62,11 +62,13 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("no index for address {address}")]
     NoIndex { address: Address },
-    #[error("wallet doesn't have a seed")]
+    #[error(
+        "wallet does not have a seed (set with RPC `set-seed-from-mnemonic`)"
+    )]
     NoSeed,
     #[error("not enough funds")]
     NotEnoughFunds,
-    #[error("utxo doesn't exist")]
+    #[error("utxo does not exist")]
     NoUtxo,
     #[error("failed to parse mnemonic seed phrase")]
     ParseMnemonic(#[source] bip39::ErrorKind),


### PR DESCRIPTION
This is required for us to be able to connect to remotely running Thunder instances.