### PR TITLE
multi: refactor mailbox item handling, more logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]

--- a/app/app.rs
+++ b/app/app.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use futures::{StreamExt, TryFutureExt};
 use parking_lot::RwLock;
@@ -206,6 +206,7 @@ impl App {
             format!("{}", config.mainchain_grpc_url),
         )
         .unwrap()
+        .timeout(Duration::from_secs(10))
         .concurrency_limit(256)
         .connect_lazy();
         let (cusf_mainchain, cusf_mainchain_wallet) = if runtime

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -51,6 +51,7 @@ tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
 utoipa = { workspace = true, features = ["macros", "non_strict_integers"] }
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/lib/net/peer.rs
+++ b/lib/net/peer.rs
@@ -139,7 +139,7 @@ impl std::fmt::Display for PeerStateId {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, strum::Display)]
 pub enum Response {
     Block {
         header: Header,
@@ -157,7 +157,9 @@ pub enum Response {
     TransactionRejected(Txid),
 }
 
-#[derive(BorshSerialize, Clone, Debug, Deserialize, Serialize)]
+#[derive(
+    BorshSerialize, Clone, Debug, Deserialize, Serialize, strum::Display,
+)]
 pub enum Request {
     Heartbeat(PeerState),
     GetBlock {

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -378,7 +378,7 @@ impl Accumulator {
             .0
             .modify(&insertions, &deletions)
             .map_err(UtreexoError)?;
-        tracing::debug!(accumulator = %self.0, "Applied diff");
+        tracing::trace!(accumulator = %self.0, "Applied diff");
         Ok(())
     }
 


### PR DESCRIPTION
The idea with the mailbox item handling refactor is to make it possible to add tracing IDs to better figure out what's happening. 

There's currently a linter failure here, which I'm not sure how to handle. @Ash-L2L are you able to help?