### PR TITLE
multi: add endpoints for best mainchain and sidechain hashes

### DIFF
--- a/app/rpc_server.rs
+++ b/app/rpc_server.rs
@@ -98,6 +98,29 @@ impl RpcServer for RpcServerImpl {
         Ok(Some(block))
     }
 
+    async fn get_best_sidechain_block_hash(
+        &self,
+    ) -> RpcResult<Option<thunder::types::BlockHash>> {
+        self.app.node.try_get_tip().map_err(custom_err)
+    }
+
+    async fn get_best_mainchain_block_hash(
+        &self,
+    ) -> RpcResult<Option<bitcoin::BlockHash>> {
+        let Some(sidechain_hash) =
+            self.app.node.try_get_tip().map_err(custom_err)?
+        else {
+            // No sidechain tip, so no best mainchain block hash.
+            return Ok(None);
+        };
+        let block_hash = self
+            .app
+            .node
+            .get_best_main_verification(sidechain_hash)
+            .map_err(custom_err)?;
+        Ok(Some(block_hash))
+    }
+
     async fn get_bmm_inclusions(
         &self,
         block_hash: thunder::types::BlockHash,

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -14,7 +14,9 @@ pub enum Command {
     /// Get balance in sats
     Balance,
     /// Connect to a peer
-    ConnectPeer { addr: SocketAddr },
+    ConnectPeer {
+        addr: SocketAddr,
+    },
     /// Deposit to address
     CreateDeposit {
         address: Address,
@@ -24,7 +26,9 @@ pub enum Command {
         fee_sats: u64,
     },
     /// Format a deposit address
-    FormatDepositAddress { address: Address },
+    FormatDepositAddress {
+        address: Address,
+    },
     /// Generate a mnemonic seed phrase
     GenerateMnemonic,
     /// Get the best mainchain block hash
@@ -64,9 +68,13 @@ pub enum Command {
     #[command(name = "openapi-schema")]
     OpenApiSchema,
     /// Remove a tx from the mempool
-    RemoveFromMempool { txid: Txid },
+    RemoveFromMempool {
+        txid: Txid,
+    },
     /// Set the wallet seed from a mnemonic seed phrase
-    SetSeedFromMnemonic { mnemonic: String },
+    SetSeedFromMnemonic {
+        mnemonic: String,
+    },
     /// Get total sidechain wealth
     SidechainWealth,
     /// Stop the node

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -27,6 +27,10 @@ pub enum Command {
     FormatDepositAddress { address: Address },
     /// Generate a mnemonic seed phrase
     GenerateMnemonic,
+    /// Get the best mainchain block hash
+    GetBestMainchainBlockHash,
+    /// Get the best sidechain block hash
+    GetBestSidechainBlockHash,
     /// Get the block with specified block hash, if it exists
     GetBlock {
         block_hash: thunder::types::BlockHash,
@@ -136,6 +140,14 @@ where
         Command::GetBlock { block_hash } => {
             let block = rpc_client.get_block(block_hash).await?;
             serde_json::to_string_pretty(&block)?
+        }
+        Command::GetBestMainchainBlockHash => {
+            let block_hash = rpc_client.get_best_mainchain_block_hash().await?;
+            serde_json::to_string_pretty(&block_hash)?
+        }
+        Command::GetBestSidechainBlockHash => {
+            let block_hash = rpc_client.get_best_sidechain_block_hash().await?;
+            serde_json::to_string_pretty(&block_hash)?
         }
         Command::GetBmmInclusions { block_hash } => {
             let bmm_inclusions =

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -14,9 +14,7 @@ pub enum Command {
     /// Get balance in sats
     Balance,
     /// Connect to a peer
-    ConnectPeer {
-        addr: SocketAddr,
-    },
+    ConnectPeer { addr: SocketAddr },
     /// Deposit to address
     CreateDeposit {
         address: Address,
@@ -26,9 +24,7 @@ pub enum Command {
         fee_sats: u64,
     },
     /// Format a deposit address
-    FormatDepositAddress {
-        address: Address,
-    },
+    FormatDepositAddress { address: Address },
     /// Generate a mnemonic seed phrase
     GenerateMnemonic,
     /// Get the best mainchain block hash
@@ -68,13 +64,9 @@ pub enum Command {
     #[command(name = "openapi-schema")]
     OpenApiSchema,
     /// Remove a tx from the mempool
-    RemoveFromMempool {
-        txid: Txid,
-    },
+    RemoveFromMempool { txid: Txid },
     /// Set the wallet seed from a mnemonic seed phrase
-    SetSeedFromMnemonic {
-        mnemonic: String,
-    },
+    SetSeedFromMnemonic { mnemonic: String },
     /// Get total sidechain wealth
     SidechainWealth,
     /// Stop the node

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -318,6 +318,12 @@ where
         Ok(utxos)
     }
 
+    pub fn try_get_tip(&self) -> Result<Option<BlockHash>, Error> {
+        let rotxn = self.env.read_txn().map_err(EnvError::from)?;
+        let tip = self.state.try_get_tip(&rotxn).map_err(DbError::from)?;
+        Ok(tip)
+    }
+
     pub fn get_tip_accumulator(&self) -> Result<Accumulator, Error> {
         let rotxn = self.env.read_txn().map_err(EnvError::from)?;
         Ok(self.state.get_accumulator(&rotxn)?)
@@ -396,6 +402,15 @@ where
     pub fn get_body(&self, block_hash: BlockHash) -> Result<Body, Error> {
         let rotxn = self.env.read_txn().map_err(EnvError::from)?;
         Ok(self.archive.get_body(&rotxn, block_hash)?)
+    }
+
+    pub fn get_best_main_verification(
+        &self,
+        hash: BlockHash,
+    ) -> Result<bitcoin::BlockHash, Error> {
+        let rotxn = self.env.read_txn().map_err(EnvError::from)?;
+        let hash = self.archive.get_best_main_verification(&rotxn, hash)?;
+        Ok(hash)
     }
 
     pub fn get_bmm_inclusions(

--- a/lib/types/hashes.rs
+++ b/lib/types/hashes.rs
@@ -24,7 +24,7 @@ pub type Hash = [u8; BLAKE3_LENGTH];
     PartialOrd,
     Serialize,
 )]
-pub struct BlockHash(pub Hash);
+pub struct BlockHash(#[serde(with = "serde_hexstr_human_readable")] pub Hash);
 
 impl From<Hash> for BlockHash {
     fn from(other: Hash) -> Self {

--- a/lib/types/schema.rs
+++ b/lib/types/schema.rs
@@ -20,6 +20,21 @@ impl ToSchema for BitcoinAddr {
     }
 }
 
+pub struct ThunderBlockHash;
+
+impl PartialSchema for ThunderBlockHash {
+    fn schema() -> RefOr<Schema> {
+        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
+        RefOr::T(Schema::Object(obj))
+    }
+}
+
+impl ToSchema for ThunderBlockHash {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("thunder.BlockHash")
+    }
+}
+
 pub struct BitcoinBlockHash;
 
 impl PartialSchema for BitcoinBlockHash {

--- a/lib/types/schema.rs
+++ b/lib/types/schema.rs
@@ -20,21 +20,6 @@ impl ToSchema for BitcoinAddr {
     }
 }
 
-pub struct ThunderBlockHash;
-
-impl PartialSchema for ThunderBlockHash {
-    fn schema() -> RefOr<Schema> {
-        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
-        RefOr::T(Schema::Object(obj))
-    }
-}
-
-impl ToSchema for ThunderBlockHash {
-    fn name() -> std::borrow::Cow<'static, str> {
-        std::borrow::Cow::Borrowed("thunder.BlockHash")
-    }
-}
-
 pub struct BitcoinBlockHash;
 
 impl PartialSchema for BitcoinBlockHash {

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -7,8 +7,8 @@ use l2l_openapi::open_api;
 use thunder::{
     net::Peer,
     types::{
-        schema as thunder_schema, Address, MerkleRoot, OutPoint, Output,
-        OutputContent, PointedOutput, Txid, WithdrawalBundle,
+        schema as thunder_schema, Address, BlockHash, MerkleRoot, OutPoint,
+        Output, OutputContent, PointedOutput, Txid, WithdrawalBundle,
     },
     wallet::Balance,
 };
@@ -16,7 +16,7 @@ use thunder::{
 mod schema;
 
 #[open_api(ref_schemas[
-    Address, MerkleRoot, OutPoint, Output, OutputContent, Txid,
+    Address, MerkleRoot, OutPoint, Output, OutputContent, Txid, BlockHash,
     schema::BitcoinTxid, thunder_schema::BitcoinAddr,
     thunder_schema::BitcoinOutPoint,
 ])]
@@ -73,6 +73,24 @@ pub trait Rpc {
         &self,
         block_hash: thunder::types::BlockHash,
     ) -> RpcResult<Vec<bitcoin::BlockHash>>;
+
+    /// Get the best mainchain block hash known by Thunder
+    #[open_api_method(output_schema(
+        PartialSchema = "thunder_schema::BitcoinBlockHash"
+    ))]
+    #[method(name = "get_best_mainchain_block_hash")]
+    async fn get_best_mainchain_block_hash(
+        &self,
+    ) -> RpcResult<Option<bitcoin::BlockHash>>;
+
+    /// Get the best sidechain block hash known by Thunder
+    #[open_api_method(output_schema(
+        PartialSchema = "thunder_schema::ThunderBlockHash"
+    ))]
+    #[method(name = "get_best_sidechain_block_hash")]
+    async fn get_best_sidechain_block_hash(
+        &self,
+    ) -> RpcResult<Option<thunder::types::BlockHash>>;
 
     /// Get a new address
     #[method(name = "get_new_address")]

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -7,8 +7,8 @@ use l2l_openapi::open_api;
 use thunder::{
     net::Peer,
     types::{
-        schema as thunder_schema, Address, BlockHash, MerkleRoot, OutPoint,
-        Output, OutputContent, PointedOutput, Txid, WithdrawalBundle,
+        schema as thunder_schema, Address, MerkleRoot, OutPoint, Output,
+        OutputContent, PointedOutput, Txid, WithdrawalBundle,
     },
     wallet::Balance,
 };
@@ -16,7 +16,7 @@ use thunder::{
 mod schema;
 
 #[open_api(ref_schemas[
-    Address, MerkleRoot, OutPoint, Output, OutputContent, Txid, BlockHash,
+    Address, MerkleRoot, OutPoint, Output, OutputContent, Txid,
     schema::BitcoinTxid, thunder_schema::BitcoinAddr,
     thunder_schema::BitcoinOutPoint,
 ])]
@@ -32,7 +32,9 @@ pub trait Rpc {
     #[method(name = "connect_peer")]
     async fn connect_peer(
         &self,
-        #[open_api_method_arg(schema(PartialSchema = "schema::SocketAddr"))]
+        #[open_api_method_arg(schema(
+            PartialSchema = "thunder_schema::SocketAddr"
+        ))]
         addr: SocketAddr,
     ) -> RpcResult<()>;
 
@@ -76,7 +78,7 @@ pub trait Rpc {
 
     /// Get the best mainchain block hash known by Thunder
     #[open_api_method(output_schema(
-        PartialSchema = "thunder_schema::BitcoinBlockHash"
+        PartialSchema = "schema::Optional<thunder_schema::BitcoinBlockHash>"
     ))]
     #[method(name = "get_best_mainchain_block_hash")]
     async fn get_best_mainchain_block_hash(
@@ -85,7 +87,7 @@ pub trait Rpc {
 
     /// Get the best sidechain block hash known by Thunder
     #[open_api_method(output_schema(
-        PartialSchema = "thunder_schema::ThunderBlockHash"
+        PartialSchema = "schema::Optional<thunder::types::BlockHash>"
     ))]
     #[method(name = "get_best_sidechain_block_hash")]
     async fn get_best_sidechain_block_hash(

--- a/rpc-api/schema.rs
+++ b/rpc-api/schema.rs
@@ -1,5 +1,7 @@
 //! Schemas for OpenAPI
 
+use std::marker::PhantomData;
+
 use utoipa::{
     openapi::{self, RefOr, Schema},
     PartialSchema, ToSchema,
@@ -29,11 +31,20 @@ impl PartialSchema for OpenApi {
     }
 }
 
-pub struct SocketAddr;
+/// Optional `T`
+pub struct Optional<T>(PhantomData<T>);
 
-impl PartialSchema for SocketAddr {
-    fn schema() -> RefOr<Schema> {
-        let obj = utoipa::openapi::Object::with_type(openapi::Type::String);
-        RefOr::T(Schema::Object(obj))
+impl<T> PartialSchema for Optional<T>
+where
+    T: PartialSchema,
+{
+    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+        openapi::schema::OneOf::builder()
+            .item(
+                openapi::schema::Object::builder()
+                    .schema_type(openapi::schema::Type::Null),
+            )
+            .item(T::schema())
+            .into()
     }
 }


### PR DESCRIPTION
Currently the output when fetching sidechain hashes is not really on a readable format...

```
$ just cli get-best-sidechain-block-hash
[
  39,
  255,
  216,
  80,
  162,
  249,
  82,
  30,
  15,
  86,
  54,
  20,
  86,
  245,
  161,
  6,
  145,
  32,
  236,
  87,
  148,
  19,
  121,
  196,
  131,
  250,
  108,
  101,
  252,
  219,
  112,
  152
]
```