### PR TITLE
fix: added error handling for connection issues

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -14,17 +14,22 @@ async fn main() -> anyhow::Result<()> {
             Ok(())
         }
         Err(err) => {
-            match err {
-                CliError::ConnectionError { .. } => {
-                    // For connection errors, we want to show a user-friendly message
-                    // without the stack trace
-                    eprintln!("{}", err);
-                    std::process::exit(1);
+            // For all errors, we want to show a user-friendly message without the stack trace
+            // unless THUNDER_DEBUG is set
+            if std::env::var("THUNDER_DEBUG").is_ok() {
+                match err {
+                    CliError::ConnectionError { .. } => {
+                        eprintln!("{}", err);
+                        std::process::exit(1);
+                    }
+                    CliError::Other(err) => {
+                        // For other errors, we'll let anyhow handle it with the stack trace
+                        Err(err)
+                    }
                 }
-                CliError::Other(err) => {
-                    // For other errors, we'll let anyhow handle it with the stack trace
-                    Err(err)
-                }
+            } else {
+                eprintln!("{}", err);
+                std::process::exit(1);
             }
         }
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,13 +1,31 @@
 use clap::Parser;
-use thunder_app_cli_lib::Cli;
+use thunder_app_cli_lib::{Cli, CliError};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let res = cli.run().await?;
-    #[allow(clippy::print_stdout)]
-    {
-        println!("{res}");
+
+    match cli.run().await {
+        Ok(res) => {
+            #[allow(clippy::print_stdout)]
+            {
+                println!("{res}");
+            }
+            Ok(())
+        }
+        Err(err) => {
+            match err {
+                CliError::ConnectionError { .. } => {
+                    // For connection errors, we want to show a user-friendly message
+                    // without the stack trace
+                    eprintln!("{}", err);
+                    std::process::exit(1);
+                }
+                CliError::Other(err) => {
+                    // For other errors, we'll let anyhow handle it with the stack trace
+                    Err(err)
+                }
+            }
+        }
     }
-    Ok(())
 }


### PR DESCRIPTION
This PR addresses issue [#11](https://github.com/LayerTwo-Labs/thunder-rust/issues/11) by improving the error handling for connection issues in the CLI.

Added:

1. Added a custom error type `CliError` to handle connection errors more gracefully
2. Improved error messages for common connection issues:
   - DNS resolution failures
   - Connection refused errors
   - Connection timeouts
   - Protocol mismatches (HTTP vs HTTPS)
   - Invalid URL formats
   - Invalid IP addresses
   - Connection closed/reset errors
3. Added helpful suggestions for users when connection errors occur
4. Added automatic handling of URLs without the `http://` protocol prefix
5. Improved the command-line help text to indicate that the protocol is optional

Example DNS Issue:

```
Unable to connect: DNS resolution failed

Could not resolve the host name: nonexistenthost.example.com

Please check that:
  1. The hostname part of the URL is correct
  2. Your network connection is working
  3. DNS resolution is functioning properly
```

Connection Refused:

```
Unable to connect: Connection refused

Could not connect to Thunder node at http://127.0.0.1:9999/

Please check that:
  1. The Thunder node is running
  2. The RPC server is enabled
  3. The RPC address is correct (http://127.0.0.1:9999/)
  4. There are no firewall rules blocking the connection
```

Connection Timeout:

```
Unable to connect: Connection timed out

The connection to http://8.8.8.8:9999/ timed out.

This usually means:
  1. The server is not responding
  2. A firewall is blocking the connection
  3. The network path to the server is congested or down

Please check that the server is running and accessible.
```