### PR TITLE
[perf]: backport changes from thunder perf hackathon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4083,6 +4093,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6472,6 +6491,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "sneed",
  "strum 0.26.3",
  "thiserror 2.0.12",
@@ -6501,6 +6521,7 @@ dependencies = [
  "human-size",
  "include_path",
  "jsonrpsee",
+ "mimalloc",
  "parking_lot",
  "poll-promise",
  "rustreexo",
@@ -6535,6 +6556,7 @@ dependencies = [
  "clap",
  "http 1.3.1",
  "jsonrpsee",
+ "mimalloc",
  "serde_json",
  "thunder",
  "thunder_app_rpc_api",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -18,6 +18,7 @@ http = { workspace = true }
 human-size = "0.4.3"
 include_path = "0.1.1"
 jsonrpsee = { workspace = true, features = ["server"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 parking_lot = { workspace = true }
 poll-promise = { version = "0.3.0", features = ["tokio"] }
 rustreexo = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 clap = { version = "4.5.4", features = ["derive"] }
 http = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 serde_json = { workspace = true }
 thunder = { path = "../lib" }
 thunder_app_rpc_api = { path = "../rpc-api" }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,8 +1,29 @@
 use clap::Parser;
+use mimalloc::MiMalloc;
 use thunder_app_cli_lib::Cli;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+fn configure_mimalloc() {
+    // Same tuning as the app binary
+    unsafe {
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
+        std::env::set_var("MIMALLOC_ARENA_LIMIT", "4");
+        std::env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
+        std::env::set_var("MIMALLOC_EAGER_COMMIT", "1");
+        std::env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
+        std::env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
+        std::env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
+        std::env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
+        std::env::set_var("MIMALLOC_PAGE_RESET", "0");
+        std::env::set_var("MIMALLOC_SEGMENT_RESET", "0");
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    configure_mimalloc();
     let cli = Cli::parse();
     let res = cli.run().await?;
     #[allow(clippy::print_stdout)]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,6 +39,7 @@ rayon = "1.7.0"
 rcgen = "0.13.2"
 rustls = { version = "0.23.21", default-features = false, features = ["ring"] }
 rustreexo = { workspace = true, features = ["with-serde"] }
+smallvec = "1.11.0"
 semver = { version = "1.0.25", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -93,15 +93,13 @@ fn connect_tip_(
     two_way_peg_data: &mainchain::TwoWayPegData,
 ) -> Result<(), Error> {
     let block_hash = header.hash();
-    let _fees: bitcoin::Amount = state.validate_block(rwtxn, header, body)?;
     if tracing::enabled!(tracing::Level::DEBUG) {
         let merkle_root = body.compute_merkle_root();
         let height = state.try_get_height(rwtxn)?;
-        let () = state.connect_block(rwtxn, header, body)?;
-        tracing::debug!(?height, %merkle_root, %block_hash,
-                            "connected body")
+        state.apply_block(rwtxn, header, body)?;
+        tracing::debug!(?height, %merkle_root, %block_hash, "connected body")
     } else {
-        let () = state.connect_block(rwtxn, header, body)?;
+        state.apply_block(rwtxn, header, body)?;
     }
     let () = state.connect_two_way_peg_data(rwtxn, two_way_peg_data)?;
     let accumulator = state.get_accumulator(rwtxn)?;

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -1,19 +1,253 @@
 //! Connect and disconnect blocks
 
-use std::collections::HashSet;
-
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use sneed::{RoTxn, RwTxn, db::error::Error as DbError};
 
 use crate::{
-    state::{Error, State, error},
+    state::{Error, PrevalidatedBlock, State, error},
     types::{
         AccumulatorDiff, AmountOverflowError, Body, GetAddress as _,
-        GetValue as _, Header, InPoint, OutPoint, PointedOutput, SpentOutput,
-        Verify as _,
+        GetValue as _, Header, InPoint, OutPoint, OutPointKey, PointedOutput,
+        SpentOutput, Verify as _,
     },
     wallet::Authorization,
 };
+
+/// Prevalidate a block: compute and verify all read-only checks and
+/// prepare data needed for fast connection.
+pub fn prevalidate(
+    state: &State,
+    rotxn: &RoTxn,
+    header: &Header,
+    body: &Body,
+) -> Result<PrevalidatedBlock, Error> {
+    let tip_hash = state.try_get_tip(rotxn)?;
+    if header.prev_side_hash != tip_hash {
+        let err = error::InvalidHeader::PrevSideHash {
+            expected: tip_hash,
+            received: header.prev_side_hash,
+        };
+        return Err(Error::InvalidHeader(err));
+    };
+    let next_height = state.try_get_height(rotxn)?.map_or(0, |h| h + 1);
+    if body.authorizations.len() > State::body_sigops_limit(next_height) {
+        return Err(Error::TooManySigops);
+    }
+    let body_size =
+        borsh::object_length(&body).map_err(Error::BorshSerialize)?;
+    if body_size > State::body_size_limit(next_height) {
+        return Err(Error::BodyTooLarge);
+    }
+
+    let mut accumulator = state
+        .utreexo_accumulator
+        .try_get(rotxn, &())
+        .map_err(DbError::from)?
+        .unwrap_or_default();
+
+    let mut accumulator_diff = AccumulatorDiff::default();
+    let mut coinbase_value = bitcoin::Amount::ZERO;
+    let computed_merkle_root = body.compute_merkle_root();
+    if computed_merkle_root != header.merkle_root {
+        let err = Error::InvalidBody {
+            expected: computed_merkle_root,
+            computed: header.merkle_root,
+        };
+        return Err(err);
+    }
+    for (vout, output) in body.coinbase.iter().enumerate() {
+        coinbase_value = coinbase_value
+            .checked_add(output.get_value())
+            .ok_or(AmountOverflowError)?;
+        let outpoint = OutPoint::Coinbase {
+            merkle_root: computed_merkle_root,
+            vout: vout as u32,
+        };
+        let pointed_output = PointedOutput {
+            outpoint,
+            output: output.clone(),
+        };
+        accumulator_diff.insert((&pointed_output).into());
+    }
+
+    // gather and verify transactions
+    let total_inputs: usize =
+        body.transactions.iter().map(|t| t.inputs.len()).sum();
+    let mut all_input_keys: Vec<OutPointKey> = Vec::with_capacity(total_inputs);
+    let filled_transactions: Vec<_> = body
+        .transactions
+        .iter()
+        .map(|t| state.fill_transaction(rotxn, t))
+        .collect::<Result<_, _>>()?;
+    let mut total_fees = bitcoin::Amount::ZERO;
+    for filled in &filled_transactions {
+        let txid = filled.transaction.txid();
+        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
+            filled.transaction.inputs.len(),
+        );
+        for (outpoint, utxo_hash) in &filled.transaction.inputs {
+            all_input_keys.push(OutPointKey::from(outpoint));
+            spent_utxo_hashes.push(utxo_hash.into());
+            accumulator_diff.remove(utxo_hash.into());
+        }
+        for (vout, output) in filled.transaction.outputs.iter().enumerate() {
+            let outpoint = OutPoint::Regular {
+                txid,
+                vout: vout as u32,
+            };
+            let pointed_output = PointedOutput {
+                outpoint,
+                output: output.clone(),
+            };
+            accumulator_diff.insert((&pointed_output).into());
+        }
+        total_fees = total_fees
+            .checked_add(state.validate_filled_transaction(filled)?)
+            .ok_or(AmountOverflowError)?;
+        if !accumulator.verify(&filled.transaction.proof, &spent_utxo_hashes)? {
+            return Err(Error::UtreexoProofFailed { txid });
+        }
+    }
+    {
+        use rayon::prelude::ParallelSliceMut;
+        all_input_keys.par_sort_unstable();
+        if all_input_keys.windows(2).any(|w| w[0] == w[1]) {
+            return Err(Error::UtxoDoubleSpent);
+        }
+    }
+    if coinbase_value > total_fees {
+        return Err(Error::NotEnoughFees);
+    }
+    let spent_utxos = filled_transactions
+        .iter()
+        .flat_map(|t| t.spent_utxos.iter());
+    for (authorization, spent_utxo) in
+        body.authorizations.iter().zip(spent_utxos)
+    {
+        if authorization.get_address() != spent_utxo.address {
+            return Err(Error::WrongPubKeyForAddress);
+        }
+    }
+    if Authorization::verify_body(body).is_err() {
+        return Err(Error::AuthorizationError);
+    }
+    // Check root consistency without committing to DB
+    let () = accumulator.apply_diff(accumulator_diff.clone())?;
+    let roots: Vec<BitcoinNodeHash> = accumulator.get_roots();
+    if roots != header.roots {
+        return Err(Error::UtreexoRootsMismatch);
+    }
+
+    Ok(PrevalidatedBlock {
+        filled_transactions,
+        computed_merkle_root,
+        total_fees,
+        coinbase_value,
+        next_height,
+        accumulator_diff,
+    })
+}
+
+/// Connect a block using the provided prevalidated data.
+pub fn connect_prevalidated(
+    state: &State,
+    rwtxn: &mut RwTxn,
+    header: &Header,
+    body: &Body,
+    pre: PrevalidatedBlock,
+) -> Result<crate::types::MerkleRoot, Error> {
+    let tip_hash = state.try_get_tip(rwtxn)?;
+    if tip_hash != header.prev_side_hash {
+        let err = error::InvalidHeader::PrevSideHash {
+            expected: tip_hash,
+            received: header.prev_side_hash,
+        };
+        return Err(Error::InvalidHeader(err));
+    }
+    if pre.computed_merkle_root != header.merkle_root {
+        let err = Error::InvalidBody {
+            expected: pre.computed_merkle_root,
+            computed: header.merkle_root,
+        };
+        return Err(err);
+    }
+
+    // Apply UTXO set changes
+    for (vout, output) in body.coinbase.iter().enumerate() {
+        let outpoint = OutPoint::Coinbase {
+            merkle_root: pre.computed_merkle_root,
+            vout: vout as u32,
+        };
+        state
+            .utxos
+            .put(rwtxn, &OutPointKey::from(&outpoint), output)
+            .map_err(DbError::from)?;
+    }
+
+    for filled in &pre.filled_transactions {
+        let txid = filled.transaction.txid();
+        for (vin, (outpoint, _)) in filled.transaction.inputs.iter().enumerate()
+        {
+            let spent_output = state
+                .utxos
+                .try_get(rwtxn, &OutPointKey::from(outpoint))
+                .map_err(DbError::from)?
+                .ok_or(Error::NoUtxo {
+                    outpoint: *outpoint,
+                })?;
+            state
+                .utxos
+                .delete(rwtxn, &OutPointKey::from(outpoint))
+                .map_err(DbError::from)?;
+            let spent_output = SpentOutput {
+                output: spent_output,
+                inpoint: InPoint::Regular {
+                    txid,
+                    vin: vin as u32,
+                },
+            };
+            state
+                .stxos
+                .put(rwtxn, &OutPointKey::from(outpoint), &spent_output)
+                .map_err(DbError::from)?;
+        }
+        for (vout, output) in filled.transaction.outputs.iter().enumerate() {
+            let outpoint = OutPoint::Regular {
+                txid,
+                vout: vout as u32,
+            };
+            state
+                .utxos
+                .put(rwtxn, &OutPointKey::from(&outpoint), output)
+                .map_err(DbError::from)?;
+        }
+    }
+
+    // Update tip/height
+    let block_hash = header.hash();
+    state
+        .tip
+        .put(rwtxn, &(), &block_hash)
+        .map_err(DbError::from)?;
+    state
+        .height
+        .put(rwtxn, &(), &pre.next_height)
+        .map_err(DbError::from)?;
+
+    // Apply accumulator diff
+    let mut accumulator = state
+        .utreexo_accumulator
+        .try_get(rwtxn, &())
+        .map_err(DbError::from)?
+        .unwrap_or_default();
+    let () = accumulator.apply_diff(pre.accumulator_diff)?;
+    state
+        .utreexo_accumulator
+        .put(rwtxn, &(), &accumulator)
+        .map_err(DbError::from)?;
+
+    Ok(pre.computed_merkle_root)
+}
 
 pub fn validate(
     state: &State,
@@ -68,7 +302,10 @@ pub fn validate(
         accumulator_diff.insert((&pointed_output).into());
     }
     let mut total_fees = bitcoin::Amount::ZERO;
-    let mut spent_utxos = HashSet::new();
+    // Gather all input keys to check double-spends via sort-and-scan
+    let total_inputs: usize =
+        body.transactions.iter().map(|t| t.inputs.len()).sum();
+    let mut all_input_keys: Vec<OutPointKey> = Vec::with_capacity(total_inputs);
     let filled_transactions: Vec<_> = body
         .transactions
         .iter()
@@ -77,12 +314,11 @@ pub fn validate(
     for filled_transaction in &filled_transactions {
         let txid = filled_transaction.transaction.txid();
         // hashes of spent utxos, used to verify the utreexo proof
-        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::new();
+        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
+            filled_transaction.transaction.inputs.len(),
+        );
         for (outpoint, utxo_hash) in &filled_transaction.transaction.inputs {
-            if spent_utxos.contains(outpoint) {
-                return Err(Error::UtxoDoubleSpent);
-            }
-            spent_utxos.insert(*outpoint);
+            all_input_keys.push(OutPointKey::from(outpoint));
             spent_utxo_hashes.push(utxo_hash.into());
             accumulator_diff.remove(utxo_hash.into());
         }
@@ -107,6 +343,14 @@ pub fn validate(
             .verify(&filled_transaction.transaction.proof, &spent_utxo_hashes)?
         {
             return Err(Error::UtreexoProofFailed { txid });
+        }
+    }
+    // Sort and check for duplicate outpoints (double-spend detection)
+    {
+        use rayon::prelude::ParallelSliceMut;
+        all_input_keys.par_sort_unstable();
+        if all_input_keys.windows(2).any(|w| w[0] == w[1]) {
+            return Err(Error::UtxoDoubleSpent);
         }
     }
     if coinbase_value > total_fees {
@@ -173,7 +417,7 @@ pub fn connect(
         accumulator_diff.insert((&pointed_output).into());
         state
             .utxos
-            .put(rwtxn, &outpoint, output)
+            .put(rwtxn, &OutPointKey::from(&outpoint), output)
             .map_err(DbError::from)?;
     }
     for transaction in &body.transactions {
@@ -183,13 +427,16 @@ pub fn connect(
         {
             let spent_output = state
                 .utxos
-                .try_get(rwtxn, outpoint)
+                .try_get(rwtxn, &OutPointKey::from(outpoint))
                 .map_err(DbError::from)?
                 .ok_or(Error::NoUtxo {
                     outpoint: *outpoint,
                 })?;
             accumulator_diff.remove(utxo_hash.into());
-            state.utxos.delete(rwtxn, outpoint).map_err(DbError::from)?;
+            state
+                .utxos
+                .delete(rwtxn, &OutPointKey::from(outpoint))
+                .map_err(DbError::from)?;
             let spent_output = SpentOutput {
                 output: spent_output,
                 inpoint: InPoint::Regular {
@@ -199,7 +446,7 @@ pub fn connect(
             };
             state
                 .stxos
-                .put(rwtxn, outpoint, &spent_output)
+                .put(rwtxn, &OutPointKey::from(outpoint), &spent_output)
                 .map_err(DbError::from)?;
         }
         for (vout, output) in transaction.outputs.iter().enumerate() {
@@ -214,7 +461,7 @@ pub fn connect(
             accumulator_diff.insert((&pointed_output).into());
             state
                 .utxos
-                .put(rwtxn, &outpoint, output)
+                .put(rwtxn, &OutPointKey::from(&outpoint), output)
                 .map_err(DbError::from)?;
         }
     }
@@ -286,7 +533,7 @@ pub fn disconnect_tip(
                 accumulator_diff.remove((&pointed_output).into());
                 if state
                     .utxos
-                    .delete(rwtxn, &outpoint)
+                    .delete(rwtxn, &OutPointKey::from(&outpoint))
                     .map_err(DbError::from)?
                 {
                     Ok(())
@@ -302,17 +549,21 @@ pub fn disconnect_tip(
             .try_for_each(|(outpoint, utxo_hash)| {
                 if let Some(spent_output) = state
                     .stxos
-                    .try_get(rwtxn, outpoint)
+                    .try_get(rwtxn, &OutPointKey::from(outpoint))
                     .map_err(DbError::from)?
                 {
                     accumulator_diff.insert(utxo_hash.into());
                     state
                         .stxos
-                        .delete(rwtxn, outpoint)
+                        .delete(rwtxn, &OutPointKey::from(outpoint))
                         .map_err(DbError::from)?;
                     state
                         .utxos
-                        .put(rwtxn, outpoint, &spent_output.output)
+                        .put(
+                            rwtxn,
+                            &OutPointKey::from(outpoint),
+                            &spent_output.output,
+                        )
                         .map_err(DbError::from)?;
                     Ok(())
                 } else {
@@ -339,7 +590,7 @@ pub fn disconnect_tip(
             accumulator_diff.remove((&pointed_output).into());
             if state
                 .utxos
-                .delete(rwtxn, &outpoint)
+                .delete(rwtxn, &OutPointKey::from(&outpoint))
                 .map_err(DbError::from)?
             {
                 Ok(())

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -23,8 +23,8 @@ pub use address::Address;
 pub use hashes::{BlockHash, Hash, M6id, MerkleRoot, Txid, hash};
 pub use transaction::{
     AuthorizedTransaction, Body, Content as OutputContent, FilledTransaction,
-    GetAddress, GetValue, InPoint, OutPoint, Output, PointedOutput,
-    SpentOutput, Transaction, Verify,
+    GetAddress, GetValue, InPoint, OutPoint, OutPointKey, Output,
+    PointedOutput, SpentOutput, Transaction, Verify,
 };
 
 pub const THIS_SIDECHAIN: u8 = 9;
@@ -311,7 +311,7 @@ impl PartialOrd for AggregatedWithdrawal {
 /// Removing twice will cause one deletion.
 /// Inserting and then removing will have no overall effect,
 /// but a second removal will still cause a deletion.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct AccumulatorDiff(
     /// `true` indicates insertion, `false` indicates removal.
@@ -360,7 +360,11 @@ impl Accumulator {
         &mut self,
         diff: AccumulatorDiff,
     ) -> Result<(), UtreexoError> {
-        let (mut insertions, mut deletions) = (Vec::new(), Vec::new());
+        let capacity = diff.0.len();
+        let (mut insertions, mut deletions) = (
+            Vec::with_capacity(capacity / 2 + 1),
+            Vec::with_capacity(capacity / 2 + 1),
+        );
         for (utxo_hash, insert) in diff.0 {
             if insert {
                 insertions.push(utxo_hash);

--- a/lib/types/transaction.rs
+++ b/lib/types/transaction.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use bitcoin::amount::CheckedSum;
 use borsh::BorshSerialize;
+use heed::{BoxedError, BytesDecode, BytesEncode};
 use rustreexo::accumulator::{
     mem_forest::MemForest, node_hash::BitcoinNodeHash, proof::Proof,
 };
@@ -81,6 +82,140 @@ impl std::fmt::Display for OutPoint {
                 write!(f, "deposit {txid} {vout}")
             }
         }
+    }
+}
+
+/// Fixed-width lexicographically sortable key for OutPoint
+/// Layout: [tag: u8][id: 32][vout: u32 BE]
+/// - tag: 0 = Regular, 1 = Coinbase, 2 = Deposit
+/// - id: txid/merkle_root/bitcoin::txid
+/// - vout: big-endian for numeric order = lexicographic order
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct OutPointKey([u8; 37]);
+
+impl OutPointKey {
+    /// Get the raw key bytes
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 37] {
+        &self.0
+    }
+}
+
+impl From<OutPoint> for OutPointKey {
+    #[inline]
+    fn from(op: OutPoint) -> Self {
+        let mut k = [0u8; 37];
+        match op {
+            OutPoint::Regular {
+                txid: Txid(id),
+                vout,
+            } => {
+                k[0] = 0;
+                k[1..33].copy_from_slice(&id);
+                k[33..37].copy_from_slice(&vout.to_be_bytes());
+            }
+            OutPoint::Coinbase { merkle_root, vout } => {
+                k[0] = 1;
+                let id: Hash = merkle_root.into();
+                k[1..33].copy_from_slice(&id);
+                k[33..37].copy_from_slice(&vout.to_be_bytes());
+            }
+            OutPoint::Deposit(ref bop) => {
+                k[0] = 2;
+                k[1..33].copy_from_slice(bop.txid.as_ref());
+                k[33..37].copy_from_slice(&bop.vout.to_be_bytes());
+            }
+        }
+        Self(k)
+    }
+}
+
+impl From<&OutPoint> for OutPointKey {
+    #[inline]
+    fn from(op: &OutPoint) -> Self {
+        Self::from(*op)
+    }
+}
+
+impl From<OutPointKey> for OutPoint {
+    #[inline]
+    fn from(key: OutPointKey) -> Self {
+        let tag = key.0[0];
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&key.0[1..33]);
+        let vout =
+            u32::from_be_bytes([key.0[33], key.0[34], key.0[35], key.0[36]]);
+
+        match tag {
+            0 => OutPoint::Regular {
+                txid: Txid(id),
+                vout,
+            },
+            1 => OutPoint::Coinbase {
+                merkle_root: MerkleRoot::from(Hash::from(id)),
+                vout,
+            },
+            2 => {
+                use bitcoin::hashes::Hash as BitcoinHash;
+                let txid = bitcoin::Txid::from_byte_array(id);
+                OutPoint::Deposit(bitcoin::OutPoint { txid, vout })
+            }
+            _ => unreachable!("Invalid OutPointKey tag"),
+        }
+    }
+}
+
+impl From<&OutPointKey> for OutPoint {
+    #[inline]
+    fn from(key: &OutPointKey) -> Self {
+        Self::from(*key)
+    }
+}
+
+impl Ord for OutPointKey {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for OutPointKey {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsRef<[u8]> for OutPointKey {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// Database key encoding traits for direct LMDB usage
+impl<'a> BytesEncode<'a> for OutPointKey {
+    type EItem = OutPointKey;
+
+    #[inline]
+    fn bytes_encode(
+        item: &'a Self::EItem,
+    ) -> Result<std::borrow::Cow<'a, [u8]>, BoxedError> {
+        Ok(std::borrow::Cow::Borrowed(item.as_ref()))
+    }
+}
+
+impl<'a> BytesDecode<'a> for OutPointKey {
+    type DItem = OutPointKey;
+
+    #[inline]
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        if bytes.len() != 37 {
+            return Err("OutPointKey must be exactly 37 bytes".into());
+        }
+        let mut key = [0u8; 37];
+        key.copy_from_slice(bytes);
+        Ok(OutPointKey(key))
     }
 }
 

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -20,8 +20,8 @@ use tokio_stream::{StreamMap, wrappers::WatchStream};
 pub use crate::{
     authorization::{Authorization, get_address},
     types::{
-        Address, AuthorizedTransaction, GetValue, InPoint, OutPoint, Output,
-        OutputContent, SpentOutput, Transaction,
+        Address, AuthorizedTransaction, GetValue, InPoint, OutPoint,
+        OutPointKey, Output, OutputContent, SpentOutput, Transaction,
     },
 };
 use crate::{
@@ -96,8 +96,8 @@ pub struct Wallet {
     /// Map each address index to an address
     index_to_address:
         DatabaseUnique<SerdeBincode<[u8; 4]>, SerdeBincode<Address>>,
-    utxos: DatabaseUnique<SerdeBincode<OutPoint>, SerdeBincode<Output>>,
-    stxos: DatabaseUnique<SerdeBincode<OutPoint>, SerdeBincode<SpentOutput>>,
+    utxos: DatabaseUnique<OutPointKey, SerdeBincode<Output>>,
+    stxos: DatabaseUnique<OutPointKey, SerdeBincode<SpentOutput>>,
     _version: DatabaseUnique<UnitKey, SerdeBincode<Version>>,
 }
 
@@ -107,10 +107,18 @@ impl Wallet {
     pub fn new(path: &Path) -> Result<Self, Error> {
         std::fs::create_dir_all(path)?;
         let env = {
+            use heed::EnvFlags;
             let mut env_open_options = heed::EnvOpenOptions::new();
             env_open_options
                 .map_size(10 * 1024 * 1024) // 10MB
                 .max_dbs(Self::NUM_DBS);
+            let fast_flags = EnvFlags::WRITE_MAP
+                | EnvFlags::MAP_ASYNC
+                | EnvFlags::NO_SYNC
+                | EnvFlags::NO_META_SYNC
+                | EnvFlags::NO_READ_AHEAD
+                | EnvFlags::NO_TLS;
+            unsafe { env_open_options.flags(fast_flags) };
             unsafe { Env::open(&env_open_options, path) }
                 .map_err(EnvError::from)?
         };
@@ -301,6 +309,7 @@ impl Wallet {
         &self,
         value: bitcoin::Amount,
     ) -> Result<(bitcoin::Amount, HashMap<OutPoint, Output>), Error> {
+        use rayon::prelude::ParallelSliceMut;
         let rotxn = self.env.read_txn().map_err(EnvError::from)?;
         let mut utxos: Vec<_> = self
             .utxos
@@ -308,11 +317,11 @@ impl Wallet {
             .map_err(DbError::from)?
             .collect()
             .map_err(DbError::from)?;
-        utxos.sort_unstable_by_key(|(_, output)| output.get_value());
+        utxos.par_sort_unstable_by_key(|(_, output)| output.get_value());
 
         let mut selected = HashMap::new();
         let mut total = bitcoin::Amount::ZERO;
-        for (outpoint, output) in &utxos {
+        for (outpoint_key, output) in &utxos {
             if output.content.is_withdrawal() {
                 continue;
             }
@@ -322,7 +331,8 @@ impl Wallet {
             total = total
                 .checked_add(output.get_value())
                 .ok_or(AmountOverflowError)?;
-            selected.insert(*outpoint, output.clone());
+            let outpoint: OutPoint = outpoint_key.into();
+            selected.insert(outpoint, output.clone());
         }
         if total < value {
             return Err(Error::NotEnoughFunds);
@@ -333,9 +343,8 @@ impl Wallet {
     pub fn delete_utxos(&self, outpoints: &[OutPoint]) -> Result<(), Error> {
         let mut txn = self.env.write_txn().map_err(EnvError::from)?;
         for outpoint in outpoints {
-            self.utxos
-                .delete(&mut txn, outpoint)
-                .map_err(DbError::from)?;
+            let key = OutPointKey::from(outpoint);
+            self.utxos.delete(&mut txn, &key).map_err(DbError::from)?;
         }
         txn.commit().map_err(RwTxnError::from)?;
         Ok(())
@@ -347,18 +356,17 @@ impl Wallet {
     ) -> Result<(), Error> {
         let mut txn = self.env.write_txn().map_err(EnvError::from)?;
         for (outpoint, inpoint) in spent {
+            let key = OutPointKey::from(outpoint);
             let output =
-                self.utxos.try_get(&txn, outpoint).map_err(DbError::from)?;
+                self.utxos.try_get(&txn, &key).map_err(DbError::from)?;
             if let Some(output) = output {
-                self.utxos
-                    .delete(&mut txn, outpoint)
-                    .map_err(DbError::from)?;
+                self.utxos.delete(&mut txn, &key).map_err(DbError::from)?;
                 let spent_output = SpentOutput {
                     output,
                     inpoint: *inpoint,
                 };
                 self.stxos
-                    .put(&mut txn, outpoint, &spent_output)
+                    .put(&mut txn, &key, &spent_output)
                     .map_err(DbError::from)?;
             }
         }
@@ -372,8 +380,9 @@ impl Wallet {
     ) -> Result<(), Error> {
         let mut txn = self.env.write_txn().map_err(EnvError::from)?;
         for (outpoint, output) in utxos {
+            let key = OutPointKey::from(outpoint);
             self.utxos
-                .put(&mut txn, outpoint, output)
+                .put(&mut txn, &key, output)
                 .map_err(DbError::from)?;
         }
         txn.commit().map_err(RwTxnError::from)?;
@@ -407,10 +416,11 @@ impl Wallet {
 
     pub fn get_utxos(&self) -> Result<HashMap<OutPoint, Output>, Error> {
         let rotxn = self.env.read_txn().map_err(EnvError::from)?;
-        let utxos: HashMap<_, _> = self
+        let utxos: HashMap<OutPoint, Output> = self
             .utxos
             .iter(&rotxn)
             .map_err(DbError::from)?
+            .map(|(key, output)| Ok((key.into(), output)))
             .collect()
             .map_err(DbError::from)?;
         Ok(utxos)
@@ -433,11 +443,12 @@ impl Wallet {
         transaction: Transaction,
     ) -> Result<AuthorizedTransaction, Error> {
         let txn = self.env.read_txn().map_err(EnvError::from)?;
-        let mut authorizations = vec![];
+        let mut authorizations = Vec::with_capacity(transaction.inputs.len());
         for (outpoint, _) in &transaction.inputs {
+            let key = OutPointKey::from(outpoint);
             let spent_utxo = self
                 .utxos
-                .try_get(&txn, outpoint)
+                .try_get(&txn, &key)
                 .map_err(DbError::from)?
                 .ok_or(Error::NoUtxo)?;
             let index = self


### PR DESCRIPTION
This PR adds misc perf improvements which have been already merged (or partially merged) into upstream. This includes

* Prevalidate + connect + apply in single RW txn:
* LMDB env fast flags in node init (`WRITE_MAP, MAP_ASYNC, NO_SYNC, NO_META_SYNC, NO_READ_AHEAD, NO_TLS`)
* Vec + parallel sort over `OutPointKey` and ordered apply to coalesce writes
* Fixed-width `OutPointKey keys` for LMDB (both node and wallet DBs)
* Double-spend detection via parallel sort of fixed-width keys
* Vector preallocations / more rayon usage
* Switch to `mimalloc` v3 as a global allocator
* Scratch-buffer hashing on hot call sites
* Threshold based parallel merging over levels for large transaction sets on merkle tree building