### PR TITLE
ui: fix spend button not shown in Coins/Transaction Builder tab

### DIFF
--- a/app/gui/coins/tx_builder.rs
+++ b/app/gui/coins/tx_builder.rs
@@ -112,13 +112,13 @@ impl TxBuilder {
     ) -> anyhow::Result<()> {
         egui::ScrollArea::horizontal().show(ui, |ui| {
             egui::SidePanel::left("spend_utxo")
-                .exact_width(250.)
+                .exact_width(300.)
                 .resizable(false)
                 .show_inside(ui, |ui| {
                     self.utxo_selector.show(app, ui, &mut self.base_tx);
                 });
             egui::SidePanel::left("value_in")
-                .exact_width(250.)
+                .exact_width(300.)
                 .resizable(false)
                 .show_inside(ui, |ui| {
                     let () = self.show_value_in(app, ui);


### PR DESCRIPTION
The "Spend" button in the Coins/Transaction Builder tab is hidden, due to insufficient space as shown below:


<img width="1916" height="418" alt="Screenshot from 2026-05-20 02-19-24" src="https://github.com/user-attachments/assets/456096a7-10b6-4637-b371-98b87bd935cc" />

This change fixes this by increasing the width of the tab.