### PR TITLE
Spend reinstated utxos when disconnecting a failed withdrawal bundle

### DIFF
--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -865,7 +865,7 @@ fn disconnect_withdrawal_bundle_failed(
                     .stxos
                     .put(rwtxn, &OutPointKey::from(outpoint), &spent_output)
                     .map_err(DbError::from)?;
-                if state
+                if !state
                     .utxos
                     .delete(rwtxn, &OutPointKey::from(outpoint))
                     .map_err(DbError::from)?

--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -1095,3 +1095,90 @@ pub fn disconnect(
     state.utreexo_accumulator.put(rwtxn, &(), &accumulator)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Address, Txid};
+
+    // open a fresh state-backed env in a unique temp dir
+    fn temp_env() -> sneed::Env {
+        let mut path = std::env::temp_dir();
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("thunder-test-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&path).unwrap();
+        let mut opts = heed::EnvOpenOptions::new();
+        opts.map_size(16 * 1024 * 1024).max_dbs(State::NUM_DBS);
+        unsafe { sneed::Env::open(&opts, &path) }.unwrap()
+    }
+
+    // a failed known bundle reinstates its utxos as spendable, so disconnecting
+    // the failure must spend them again
+    #[test]
+    fn disconnect_failed_bundle_spends_reinstated_utxo() {
+        let env = temp_env();
+        let state = State::new(&env).unwrap();
+        let outpoint = OutPoint::Regular {
+            txid: Txid::from([1; 32]),
+            vout: 0,
+        };
+        let output = Output {
+            address: Address::ALL_ZEROS,
+            content: OutputContent::Value(bitcoin::Amount::from_sat(1000)),
+        };
+        let key = OutPointKey::from(&outpoint);
+
+        let m6id = {
+            let mut spend_utxos = BTreeMap::new();
+            spend_utxos.insert(outpoint, output.clone());
+            let bundle = WithdrawalBundle::new(
+                1,
+                bitcoin::Amount::ZERO,
+                spend_utxos,
+                Vec::new(),
+            )
+            .unwrap();
+            let m6id = bundle.compute_m6id();
+            let mut bundle_status =
+                RollBack::new(WithdrawalBundleStatus::Submitted, 0);
+            bundle_status
+                .push(WithdrawalBundleStatus::Failed, 1)
+                .unwrap();
+            let mut rwtxn = env.write_txn().unwrap();
+            state
+                .withdrawal_bundles
+                .put(
+                    &mut rwtxn,
+                    &m6id,
+                    &(WithdrawalBundleInfo::Known(bundle), bundle_status),
+                )
+                .unwrap();
+            state
+                .latest_failed_withdrawal_bundle
+                .put(&mut rwtxn, &(), &RollBack::new(m6id, 1))
+                .unwrap();
+            // the failure reinstated the utxo
+            state.utxos.put(&mut rwtxn, &key, &output).unwrap();
+            rwtxn.commit().unwrap();
+            m6id
+        };
+
+        let mut rwtxn = env.write_txn().unwrap();
+        let mut accumulator_diff = AccumulatorDiff::default();
+        disconnect_withdrawal_bundle_failed(
+            &state,
+            &mut rwtxn,
+            1,
+            &mut accumulator_diff,
+            m6id,
+        )
+        .unwrap();
+        assert!(state.utxos.try_get(&rwtxn, &key).unwrap().is_none());
+        let stxo = state.stxos.try_get(&rwtxn, &key).unwrap().unwrap();
+        assert_eq!(stxo.inpoint, InPoint::Withdrawal { m6id });
+        rwtxn.commit().unwrap();
+    }
+}


### PR DESCRIPTION
`disconnect_withdrawal_bundle_failed` has an inverted check on the utxo delete:

```rust
if state.utxos.delete(rwtxn, &OutPointKey::from(outpoint))? {
    return Err(error::NoUtxo { outpoint: *outpoint }.into());
};
```

`delete` returns `true` when it actually removes an entry. When a known withdrawal bundle fails, `connect_withdrawal_bundle_failed` reinstates its utxos as spendable. So on disconnect the utxo is present, `delete` returns `true` and the function errors with `NoUtxo` in the normal case.

The result is that a reorg disconnecting a block that carries a `Failed` event for a known bundle always fails, leaving the node unable to follow the better mainchain branch. Every other delete check in the file is correct.

## Fix

Negate the condition so it errors only when the utxo is unexpectedly absent and spends it back into `stxos` otherwise.

## Test

Added a unit test that reproduces the post-failure state (known bundle with its utxo reinstated), disconnects the failure and asserts the utxo is re-spent. It fails on the old code with the `NoUtxo` error and passes with the fix.