### PR TITLE
Account for the mainchain fee in withdrawal value to keep the peg solvent

### DIFF
--- a/lib/types/transaction.rs
+++ b/lib/types/transaction.rs
@@ -359,7 +359,14 @@ mod content {
         fn get_value(&self) -> bitcoin::Amount {
             match self {
                 Self::Value(value) => *value,
-                Self::Withdrawal { value, .. } => *value,
+                // a withdrawal removes both the payout and the mainchain fee
+                // from the sidechain, since the enforcer pays both out of the
+                // treasury
+                Self::Withdrawal {
+                    value, main_fee, ..
+                } => value
+                    .checked_add(*main_fee)
+                    .unwrap_or(bitcoin::Amount::MAX),
             }
         }
     }

--- a/lib/types/transaction.rs
+++ b/lib/types/transaction.rs
@@ -241,6 +241,51 @@ mod tests {
         }
         Ok(())
     }
+
+    // a withdrawal output must be funded for both its payout and its mainchain
+    // fee, since both leave the treasury
+    #[test]
+    fn withdrawal_value_includes_main_fee() {
+        use super::{
+            Content, FilledTransaction, GetValue, Output, Transaction,
+        };
+        use crate::types::Address;
+
+        let value = bitcoin::Amount::from_sat(1000);
+        let main_fee = bitcoin::Amount::from_sat(300);
+        let main_address = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"
+            .parse::<bitcoin::Address<bitcoin::address::NetworkUnchecked>>()
+            .unwrap();
+        let withdrawal = Output {
+            address: Address::ALL_ZEROS,
+            content: Content::Withdrawal {
+                value,
+                main_fee,
+                main_address,
+            },
+        };
+        assert_eq!(withdrawal.get_value(), value + main_fee);
+
+        let value_output = |amount| Output {
+            address: Address::ALL_ZEROS,
+            content: Content::Value(amount),
+        };
+        let withdrawal_tx = |funding| FilledTransaction {
+            transaction: Transaction {
+                outputs: vec![withdrawal.clone()],
+                ..Default::default()
+            },
+            spent_utxos: vec![value_output(funding)],
+        };
+
+        // inputs covering only the payout are insufficient
+        assert!(withdrawal_tx(value).get_fee().is_err());
+        // inputs covering payout plus mainchain fee fully fund it
+        assert_eq!(
+            withdrawal_tx(value + main_fee).get_fee().unwrap(),
+            bitcoin::Amount::ZERO
+        );
+    }
 }
 
 /// Reference to a tx input.
@@ -364,9 +409,9 @@ mod content {
                 // treasury
                 Self::Withdrawal {
                     value, main_fee, ..
-                } => value
-                    .checked_add(*main_fee)
-                    .unwrap_or(bitcoin::Amount::MAX),
+                } => {
+                    value.checked_add(*main_fee).unwrap_or(bitcoin::Amount::MAX)
+                }
             }
         }
     }

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -250,7 +250,7 @@ impl Wallet {
                 .checked_add(main_fee)
                 .ok_or(AmountOverflowError)?,
         )?;
-        let change = total - value - fee;
+        let change = total - value - fee - main_fee;
 
         let inputs: Vec<_> = coins
             .into_iter()


### PR DESCRIPTION
`get_value` for a withdrawal output returned only `value`, ignoring `main_fee`. But the enforcer pays both out of the treasury when it builds the M6: `BlindedM6::into_m6` sets `treasury_out = treasury - payout - fee`, where `payout` is the sum of the bundle payout amounts (`value`) and `fee` is the bundle's encoded mainchain fee (`main_fee`).

So each withdrawal removed `value + main_fee` from the treasury while the sidechain destroyed only `value`. Every withdrawal eroded the peg's backing by `main_fee` and since nothing bounds `main_fee`, an attacker could withdraw a tiny `value` with a large `main_fee` and drain the treasury at near-zero sidechain cost, eventually making the peg insolvent (late withdrawals hit the `checked_sub` underflow and fail).

The wallet reinforced this: `create_withdrawal` selected coins for `value + fee + main_fee` but computed `change = total - value - fee`, refunding `main_fee` back to the withdrawer.

## Fix

- `get_value` for a withdrawal returns `value + main_fee`, so the sidechain destroys exactly what leaves the treasury. Uses `checked_add` saturating at `Amount::MAX` to avoid a panic on a crafted overflowing output (such an output can never be funded, so it is rejected rather than crashing).
- `create_withdrawal` subtracts `main_fee` from the change as well, so wallet built withdrawals stay valid under the corrected accounting.

## Test

Added a unit test asserting a withdrawal output's value is `value + main_fee`, that inputs covering only `value` fail fee computation, and that inputs covering `value + main_fee` leave exactly zero fee. It fails on the old code and passes with the fix.