### PR TITLE
two_way_peg: make withdrawal-bundle output order deterministic

### DIFF
--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -307,16 +307,16 @@ pub struct AggregatedWithdrawal {
 
 impl Ord for AggregatedWithdrawal {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self == other {
-            Ordering::Equal
-        } else if self.main_fee > other.main_fee
-            || self.value > other.value
-            || self.main_address > other.main_address
-        {
-            Ordering::Greater
-        } else {
-            Ordering::Less
-        }
+        // A *total* order (lexicographic by main_fee, value, main_address). The
+        // previous `OR of >` was not antisymmetric/transitive, so the
+        // withdrawal-bundle output order (and hence compute_m6id) depended on
+        // HashMap iteration order and could differ across nodes. A real total order makes
+        // the sorted bundle canonical regardless of aggregation order.
+        (self.main_fee, self.value, &self.main_address).cmp(&(
+            other.main_fee,
+            other.value,
+            &other.main_address,
+        ))
     }
 }
 
@@ -930,4 +930,67 @@ pub(crate) static VERSION: LazyLock<Version> = LazyLock::new(|| {
 pub struct Block {
     pub header: Header,
     pub body: Body,
+}
+
+#[cfg(test)]
+mod withdrawal_bundle_order_regression {
+    use super::*;
+    use std::collections::{BTreeMap, HashMap};
+
+    use bitcoin::{Address, Amount, address::NetworkUnchecked};
+
+    fn aw(value: u64, main_fee: u64) -> AggregatedWithdrawal {
+        // value/main_fee drive the comparison; one address is enough to expose it.
+        let addr: Address<NetworkUnchecked> =
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+                .parse()
+                .unwrap();
+        AggregatedWithdrawal {
+            spend_utxos: HashMap::new(),
+            main_address: addr,
+            value: Amount::from_sat(value),
+            main_fee: Amount::from_sat(main_fee),
+        }
+    }
+
+    // Build the bundle m6id exactly as `collect_withdrawal_bundle` does, for a given
+    // (HashMap-determined) input order.
+    fn bundle_m6id(mut aggregated: Vec<AggregatedWithdrawal>) -> M6id {
+        aggregated.sort_by_key(|a| std::cmp::Reverse(a.clone()));
+        let outputs: Vec<bitcoin::TxOut> = aggregated
+            .iter()
+            .map(|a| bitcoin::TxOut {
+                value: a.value,
+                script_pubkey: a
+                    .main_address
+                    .assume_checked_ref()
+                    .script_pubkey(),
+            })
+            .collect();
+        WithdrawalBundle::new(0, Amount::ZERO, BTreeMap::new(), outputs)
+            .unwrap()
+            .compute_m6id()
+    }
+
+    // The withdrawal bundle's m6id must not depend on the order in which withdrawals
+    // were aggregated (HashMap iteration order is randomized per process). Before the
+    // total-order fix, the comparator was non-transitive and this failed.
+    #[test]
+    fn m6id_is_independent_of_aggregation_order() {
+        let a = aw(1, 3);
+        let b = aw(3, 2);
+        let c = aw(2, 1);
+        let m = bundle_m6id(vec![a.clone(), b.clone(), c.clone()]);
+        for perm in [
+            vec![c.clone(), b.clone(), a.clone()],
+            vec![b.clone(), a.clone(), c.clone()],
+            vec![a.clone(), c.clone(), b.clone()],
+        ] {
+            assert_eq!(
+                m,
+                bundle_m6id(perm),
+                "m6id must not depend on aggregation order"
+            );
+        }
+    }
 }


### PR DESCRIPTION

> **Consensus determinism bug.** `collect_withdrawal_bundle` can produce a
> different withdrawal-bundle `m6id` on different nodes for the *same* UTXO set,
> causing nodes to disagree on which on-chain M6 to process and diverge.

### Summary

`AggregatedWithdrawal`'s `Ord` impl is not a valid total order -- it returns
`Greater` if **any** of `main_fee`, `value`, or `main_address` is greater (an
`OR` of `>`), which violates antisymmetry and transitivity. For example
`A{value:100, fee:1}` and `B{value:1, fee:100}` give `A > B` (by value) **and**
`B > A` (by fee).

`collect_withdrawal_bundle` (`lib/state/two_way_peg_data.rs`) builds a `HashMap`
keyed by destination address (`:38`), reads it out with `into_values().collect()`
(`:80`) -- whose order is the map's randomized, per-process iteration order -- then
`sort_by_key`s that `Vec` with this comparator (`:81`). Because the comparator is
non-transitive the sort cannot impose a canonical order, so the random input order
survives into the result. That order becomes the bundle's outputs (`:85-99`), so the
bundle txid -- the `m6id` (`compute_txid`) -- differs.

Two honest nodes with the identical UTXO set therefore compute **different**
`m6id`s. When the M6 is later confirmed on the mainchain,
`connect_withdrawal_bundle_submitted` only processes it if the node's locally
computed `m6id` matches; a node that computed a different ordering takes the
`Unknown` branch and never deletes the withdrawn UTXOs, while matching nodes do.
Their UTXO sets -- and thus the committed utreexo roots in the block header --
diverge, so the nodes reject each other's blocks.

This is reachable by ordinary user withdrawals (>=3 aggregated destinations whose
`value`/`main_fee` orderings form a cycle under the broken comparator); no
attacker is required.

### The path, annotated (`lib/state/two_way_peg_data.rs`)

```rust
// :38  build a HashMap keyed by destination address (default, randomized RandomState)
let mut address_to_aggregated_withdrawal =
    HashMap::<Address, AggregatedWithdrawal>::new();
//      ...populated by iterating the UTXO set, summing value + main_fee per address...

// :80  *** consume the map -> Vec, in the map's RANDOMIZED iteration order ***
let mut aggregated_withdrawals: Vec<_> =
    address_to_aggregated_withdrawal.into_values().collect();

// :81  sort that Vec with AggregatedWithdrawal's Ord (the non-total-order comparator)
aggregated_withdrawals.sort_by_key(|a| std::cmp::Reverse(a.clone()));

// :85  the bundle's outputs are pushed IN THAT SORTED ORDER
for aggregated in &aggregated_withdrawals { /* ... */ bundle_outputs.push(out); }

// :100 the bundle transaction's id IS the m6id -- order-sensitive
let bundle = WithdrawalBundle::new(block_height, fee, spend_utxos, bundle_outputs)?;
//           bundle.compute_m6id() == bundle.tx.compute_txid()
```

`:80` is the only nondeterministic step; the non-total-order `Ord` on `:81` is what
lets that randomness survive all the way to the `m6id` on `:100`. (`spend_utxos` is a
`BTreeMap`, so the *set* of withdrawn UTXOs is unaffected -- only the output *order*.)

### Why the same UTXO set yields different `m6id`s on different nodes

The aggregation map is a `std::collections::HashMap`, and its **iteration order is
not a function of its contents** -- each map instance seeds a random hasher
(`RandomState`) at creation, for HashDoS resistance. So two nodes holding the
*identical* set of withdrawals get *different* `into_values()` orders. Normally
that is harmless because a sort follows -- a correct total order re-canonicalizes
any input permutation to the same output. This comparator is not a total order, so
the per-node iteration order is **not** neutralized: it flows straight through to
the bundle's output order and hence the `m6id`.

It takes **both** ingredients. With a deterministic input (e.g. a `BTreeMap`) every
node would feed the *same* order to the broken sort and still agree (on a
wrong-but-consistent order); with a correct comparator the sort would canonicalize
the random order away. Only the combination diverges. Note `spend_utxos` (`:82`) is
a `BTreeMap`, so the *set* of withdrawn UTXOs stays consistent across nodes -- only
the output *order*, and therefore the `m6id`, is affected.

<details><summary>Same program, same data, 5 runs (= 5 nodes) -> 5 different orders</summary>

```text
// HashMap of the same three withdrawals, keyed by address; print iteration order:
iteration order: ["addr_A", "addr_C", "addr_B"]
iteration order: ["addr_C", "addr_A", "addr_B"]
iteration order: ["addr_A", "addr_B", "addr_C"]
iteration order: ["addr_C", "addr_B", "addr_A"]
iteration order: ["addr_B", "addr_A", "addr_C"]
```
</details>

### Fix

Replace the comparator with a real total order (lexicographic), so the sorted
bundle is canonical regardless of `HashMap` iteration order:

```rust
fn cmp(&self, other: &Self) -> Ordering {
    (self.main_fee, self.value, &self.main_address)
        .cmp(&(other.main_fee, other.value, &other.main_address))
}
```

`bitcoin::Address<NetworkUnchecked>` derives `Ord`, so this is well-defined; with
the existing `sort_by_key(Reverse(..))` it gives a stable descending order for any
input permutation.

### Regression test (included in this commit)

This commit adds `m6id_is_independent_of_aggregation_order`, which builds the same
withdrawal set in several input orders through the real
`sort_by_key(Reverse) -> WithdrawalBundle::new -> compute_m6id` pipeline and asserts
the resulting `m6id` is identical. It is **red without this fix, green with it**:

```text
# broken comparator (before this fix):
assertion `left == right` failed: m6id must not depend on aggregation order
test result: FAILED. 0 passed; 1 failed

# with this fix:
test types::...::m6id_is_independent_of_aggregation_order ... ok
test result: ok. 1 passed; 0 failed
```

<details><summary>Optional: a two-node consensus-fork demonstration (no node, in-crate)</summary>

A heavier variant stands up two `State` instances on temp DBs, seeds them
**identically** (same UTXO set, same accumulator -> same initial roots), gives them
the two bug-induced pending `m6id`s, and applies the **same** on-chain
`WithdrawalBundleEvent { Submitted, m6id: A }` to both via the real
`State::connect_two_way_peg_data`. The matching node deletes the withdrawn UTXOs
(roots -> `[empty, empty]`); the mismatching node takes the `Unknown` path and
deletes nothing (roots unchanged) -> the two nodes commit **different** utreexo
roots. Happy to share this test if useful.
</details>

### Sibling sidechains

The same `AggregatedWithdrawal` `Ord` and `collect_withdrawal_bundle` pipeline are
duplicated in `plain-bitassets`, `coinshift-rs`, `zside`, `truthcoin-dc`, `photon`,
and `plain-bitnames` (its types live in a separate `types/` crate); the same
one-line fix applies to each.


