### PR TITLE
Disconnect two-way peg data at the connecting block height

### DIFF
--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -1403,4 +1403,98 @@ mod tests {
         );
         Ok(())
     }
+
+    // connecting a deposit then disconnecting it on a reorg must round-trip
+    #[test]
+    fn deposit_reorg_round_trips() {
+        use crate::types::proto::mainchain::Deposit;
+        use crate::types::{Body, FilledTransaction, Header};
+
+        let env = temp_env("deposit_reorg_round_trips");
+        let state = State::new(&env).unwrap();
+
+        let empty_body = Body {
+            coinbase: Vec::new(),
+            transactions: Vec::new(),
+            authorizations: Vec::new(),
+        };
+        let no_txs: &[FilledTransaction] = &[];
+        let merkle_root = Body::compute_merkle_root(&[], no_txs).unwrap();
+        let main0 = bitcoin::BlockHash::from_byte_array([10; 32]);
+        let main1 = bitcoin::BlockHash::from_byte_array([11; 32]);
+
+        let genesis = Header {
+            merkle_root,
+            prev_side_hash: None,
+            prev_main_hash: main0,
+            roots: Vec::new(),
+        };
+        {
+            let mut rwtxn = env.write_txn().unwrap();
+            state
+                .apply_block(&mut rwtxn, &genesis, &empty_body)
+                .unwrap();
+            state
+                .connect_two_way_peg_data(&mut rwtxn, &TwoWayPegData::default())
+                .unwrap();
+            rwtxn.commit().unwrap();
+        }
+
+        let block1 = Header {
+            merkle_root,
+            prev_side_hash: Some(genesis.hash()),
+            prev_main_hash: main1,
+            roots: Vec::new(),
+        };
+        let deposit_outpoint = bitcoin::OutPoint {
+            txid: bitcoin::Txid::from_byte_array([2; 32]),
+            vout: 0,
+        };
+        let deposit_key =
+            OutPointKey::from(&OutPoint::Deposit(deposit_outpoint));
+        let deposit_twpd = {
+            let mut block_info = LinkedHashMap::new();
+            block_info.insert(
+                main1,
+                BlockInfo {
+                    bmm_commitment: None,
+                    events: vec![BlockEvent::Deposit(Deposit {
+                        tx_index: 0,
+                        outpoint: deposit_outpoint,
+                        output: Output {
+                            address: Address::ALL_ZEROS,
+                            content: OutputContent::Value(
+                                bitcoin::Amount::from_sat(1000),
+                            ),
+                        },
+                    })],
+                },
+            );
+            TwoWayPegData { block_info }
+        };
+        {
+            let mut rwtxn = env.write_txn().unwrap();
+            state.apply_block(&mut rwtxn, &block1, &empty_body).unwrap();
+            state
+                .connect_two_way_peg_data(&mut rwtxn, &deposit_twpd)
+                .unwrap();
+            assert!(
+                state.utxos.try_get(&rwtxn, &deposit_key).unwrap().is_some()
+            );
+            assert!(state.deposit_blocks.last(&rwtxn).unwrap().is_some());
+            rwtxn.commit().unwrap();
+        }
+
+        {
+            let mut rwtxn = env.write_txn().unwrap();
+            state
+                .disconnect_two_way_peg_data(&mut rwtxn, &deposit_twpd)
+                .unwrap();
+            assert!(
+                state.utxos.try_get(&rwtxn, &deposit_key).unwrap().is_none()
+            );
+            assert!(state.deposit_blocks.last(&rwtxn).unwrap().is_none());
+            rwtxn.commit().unwrap();
+        }
+    }
 }

--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -1049,7 +1049,7 @@ pub fn disconnect(
             latest_withdrawal_bundle_event_block_hash,
             last_withdrawal_bundle_event_block_hash
         );
-        assert_eq!(block_height - 1, last_withdrawal_bundle_event_block_height);
+        assert_eq!(block_height, last_withdrawal_bundle_event_block_height);
         if !state
             .withdrawal_bundle_event_blocks
             .delete(rwtxn, &last_withdrawal_bundle_event_block_seq_idx)?
@@ -1062,14 +1062,14 @@ pub fn disconnect(
         .map(|(height, _bundle)| height)
         .unwrap_or_default();
     if block_height - last_withdrawal_bundle_failure_height
-        > WITHDRAWAL_BUNDLE_FAILURE_GAP
+        >= WITHDRAWAL_BUNDLE_FAILURE_GAP
         && let Some(bundle_m6id) =
             state.pending_withdrawal_bundle.try_get(rwtxn, &())?
         && let (bundle, bundle_status) = state
             .withdrawal_bundles
             .try_get(rwtxn, &bundle_m6id)?
             .ok_or(error::PendingWithdrawalBundleUnknown(bundle_m6id))?
-        && bundle_status.latest().height == block_height - 1
+        && bundle_status.latest().height == block_height
     {
         state.pending_withdrawal_bundle.delete(rwtxn, &())?;
         if let (Some(bundle_status), _latest_bundle_status) =
@@ -1094,7 +1094,7 @@ pub fn disconnect(
             .last(rwtxn)?
             .ok_or(Error::NoDepositBlock)?;
         assert_eq!(latest_deposit_block_hash, last_deposit_block_hash);
-        assert_eq!(block_height - 1, last_deposit_block_height);
+        assert_eq!(block_height, last_deposit_block_height);
         if !state
             .deposit_blocks
             .delete(rwtxn, &last_deposit_block_seq_idx)?
@@ -1255,12 +1255,12 @@ mod tests {
             .unwrap();
         state
             .withdrawal_bundle_event_blocks
-            .put(&mut rwtxn, &0, &(event_block_hash, block_height - 1))
+            .put(&mut rwtxn, &0, &(event_block_hash, block_height))
             .unwrap();
         // a deposit record at the same sequence index that must survive
         state
             .deposit_blocks
-            .put(&mut rwtxn, &0, &(deposit_block_hash, block_height - 1))
+            .put(&mut rwtxn, &0, &(deposit_block_hash, block_height))
             .unwrap();
         rwtxn.commit().unwrap();
 


### PR DESCRIPTION
`disconnect_two_way_peg_data` asserted that the most recent `deposit_blocks` record, `withdrawal_bundle_event_blocks` record and pending withdrawal-bundle status were stamped at `block_height` - 1 and gated the pending-bundle removal on `block_height` - last_failure > `WITHDRAWAL_BUNDLE_FAILURE_GAP`.

`connect_two_way_peg_data` stamps all of these at `block_height` and every other status assertion in disconnect already uses `block_height`. `connect` and `disconnect` of the same block run at the same height (`connect_prevalidated_block` bumps the height before `connect_two_way_peg_data` and `disconnect_two_way_peg_data` runs before `disconnect_tip` reverts it), so the `block_height` - 1 checks never matched.

As a result, disconnecting a sidechain block that applied a mainchain deposit or withdrawal-bundle event on a reorg panicked on the assertion and a pending bundle created by that block was never removed. This wedges a node on any mainchain reorg that orphans such a block. The off-by-one also underflowed at height 0.

Align the four checks with connect (`block_height`, >=). This also matches the existing disconnect status assertions. Add a regression test that connects a deposit and disconnects it through the real connect/disconnect paths.

---

## Fuzzing logs

Assertion failure (reorg of a deposit block at height >= 1):

```
#48  NEW  cov: 871 ft: 1344 corp: 7/14b lim: 4 exec/s: 0 rss: 91Mb
thread '<unnamed>' panicked at lib/state/two_way_peg_data.rs:1097:20:
assertion `left == right` failed
  left: 0
 right: 1
==97316== ERROR: libFuzzer: deadly signal
SUMMARY: libFuzzer: deadly signal
```

Underflow variant (deposit in the first block, height 0), minimized input [65, 6, 10, 93]:

```
Running: fuzz/artifacts/twpd_reorg/crash-d4bd2cd642d9180ad4919e39be30c6efbc7cd8e7
thread '<unnamed>' panicked at lib/state/two_way_peg_data.rs:1097:20:
attempt to subtract with overflow
==97405== ERROR: libFuzzer: deadly signal
SUMMARY: libFuzzer: deadly signal
artifact_prefix='.../artifacts/twpd_reorg/';
Test unit written to .../crash-d4bd2cd642d9180ad4919e39be30c6efbc7cd8e7
Base64: QQYKXQ==
```