### PR TITLE
Verify transaction input hash commits to the spent output

### DIFF
--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -9,7 +9,8 @@ use crate::{
     types::{
         AccumulatorDiff, AmountOverflowError, Body, FilledTransaction,
         GetAddress as _, GetValue as _, Header, InPoint, MerkleRoot, OutPoint,
-        OutPointKey, PointedOutput, SpentOutput, Verify as _,
+        OutPointKey, PointedOutput, PointedOutputRef, SpentOutput, Verify as _,
+        hash,
     },
 };
 
@@ -71,6 +72,16 @@ pub fn prevalidate(
                 state.utxos.try_get(rotxn, &key)?.ok_or(error::NoUtxo {
                     outpoint: *outpoint,
                 })?;
+            // The input hash must commit to the output being spent
+            let expected = hash(&PointedOutputRef {
+                outpoint: *outpoint,
+                output: &spent_output,
+            });
+            if expected != *utxo_hash {
+                return Err(Error::UtxoHashMismatch {
+                    outpoint: *outpoint,
+                });
+            }
             all_input_keys.push(OutPointKey::from(outpoint));
             spent_utxos.push(spent_output);
             spent_utxo_hashes.push(utxo_hash.into());
@@ -346,7 +357,22 @@ pub fn validate(
         let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
             filled_transaction.transaction.inputs.len(),
         );
-        for (outpoint, utxo_hash) in &filled_transaction.transaction.inputs {
+        for ((outpoint, utxo_hash), spent_output) in filled_transaction
+            .transaction
+            .inputs
+            .iter()
+            .zip(&filled_transaction.spent_utxos)
+        {
+            // The input hash must commit to the output being spent
+            let expected = hash(&PointedOutputRef {
+                outpoint: *outpoint,
+                output: spent_output,
+            });
+            if expected != *utxo_hash {
+                return Err(Error::UtxoHashMismatch {
+                    outpoint: *outpoint,
+                });
+            }
             all_input_keys.push(OutPointKey::from(outpoint));
             spent_utxo_hashes.push(utxo_hash.into());
             accumulator_diff.remove(utxo_hash.into());

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -649,3 +649,105 @@ pub fn disconnect_tip(
         .map_err(DbError::from)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Amount, hashes::Hash as _};
+
+    use super::*;
+    use crate::types::{
+        Accumulator, AccumulatorDiff, Address, Output, OutputContent,
+        Transaction, Txid,
+    };
+
+    fn temp_env(name: &str) -> sneed::Env {
+        let mut path = std::env::temp_dir();
+        path.push(format!("thunder-block-test-{name}"));
+        std::fs::remove_dir_all(&path).ok();
+        std::fs::create_dir_all(&path).unwrap();
+        let mut opts = heed::EnvOpenOptions::new();
+        opts.map_size(16 * 1024 * 1024).max_dbs(State::NUM_DBS);
+        unsafe { sneed::Env::open(&opts, &path) }.unwrap()
+    }
+
+    fn value_output(n: u8) -> (OutPoint, Output) {
+        let outpoint = OutPoint::Regular {
+            txid: Txid::from([n; 32]),
+            vout: 0,
+        };
+        let output = Output {
+            address: Address::ALL_ZEROS,
+            content: OutputContent::Value(Amount::from_sat(1000)),
+        };
+        (outpoint, output)
+    }
+
+    // An input commits to (outpoint, utxo_hash). Spending one outpoint while
+    // supplying a different (but provable) leaf hash must be rejected.
+    #[test]
+    fn rejects_input_hash_not_matching_spent_output() {
+        let env = temp_env("rejects_input_hash_not_matching_spent_output");
+        let state = State::new(&env).unwrap();
+
+        let (outpoint_a, output_a) = value_output(1);
+        let (outpoint_b, output_b) = value_output(2);
+        let hash_b = hash(&PointedOutput {
+            outpoint: outpoint_b,
+            output: output_b.clone(),
+        });
+
+        let mut accumulator = Accumulator::default();
+        let mut diff = AccumulatorDiff::default();
+        diff.insert(
+            hash(&PointedOutput {
+                outpoint: outpoint_a,
+                output: output_a.clone(),
+            })
+            .into(),
+        );
+        diff.insert(hash_b.into());
+        accumulator.apply_diff(diff).unwrap();
+        let proof = accumulator.prove(&[hash_b.into()]).unwrap();
+
+        let mut rwtxn = env.write_txn().unwrap();
+        state
+            .utxos
+            .put(&mut rwtxn, &OutPointKey::from(&outpoint_a), &output_a)
+            .unwrap();
+        state
+            .utxos
+            .put(&mut rwtxn, &OutPointKey::from(&outpoint_b), &output_b)
+            .unwrap();
+        state
+            .utreexo_accumulator
+            .put(&mut rwtxn, &(), &accumulator)
+            .unwrap();
+        rwtxn.commit().unwrap();
+
+        // Spend outpoint_a but claim outpoint_b's leaf hash + a valid proof
+        let tx = Transaction {
+            inputs: vec![(outpoint_a, hash_b)],
+            proof,
+            outputs: vec![output_a],
+        };
+        let body = Body {
+            coinbase: vec![],
+            transactions: vec![tx],
+            authorizations: vec![],
+        };
+        let header = Header {
+            merkle_root: [0u8; 32].into(),
+            prev_side_hash: None,
+            prev_main_hash: bitcoin::BlockHash::all_zeros(),
+            roots: vec![],
+        };
+
+        let rotxn = env.read_txn().unwrap();
+        let result = prevalidate(&state, &rotxn, &header, &body);
+        eprintln!("prevalidate result: {result:?}");
+        assert!(
+            matches!(result, Err(Error::UtxoHashMismatch { outpoint }) if outpoint == outpoint_a),
+            "expected UtxoHashMismatch, got {result:?}"
+        );
+    }
+}

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -174,6 +174,8 @@ pub enum Error {
     UtreexoRootsMismatch,
     #[error("utxo double spent")]
     UtxoDoubleSpent,
+    #[error("utxo hash for {outpoint} does not match the spent output")]
+    UtxoHashMismatch { outpoint: OutPoint },
     #[error("too many sigops")]
     TooManySigops,
     #[error(


### PR DESCRIPTION
Block validation does not bind a transaction input's `utxo_hash` to the `OutPoint` it spends. Each input is `(OutPoint, Hash)`; validation sources the spent value and owner from the UTXO DB **by `OutPoint`** but sources utreexo membership and removal **from the caller-supplied `Hash`** and `accumulator.verify` only checks that hash against the supplied proof. Nothing asserts `utxo_hash == hash(PointedOutput { outpoint, spent_output })`.

The binding is computed only in `wallet.rs` (honest construction) and `two_way_peg_data.rs` (system-generated) — never in the four block paths in `lib/state/block.rs` (`prevalidate`, `validate`, `connect`, `connect_prevalidated`).

An attacker spends one of their own outpoints but supplies a **different** (provable) leaf hash e.g. a victim's UTXO leaf, whose hash and membership proof are derivable from the committed accumulator. Validation accepts it: value comes from the attacker's outpoint, the proof verifies against the cited leaf. On connect, the DB deletes the attacker's outpoint while the accumulator removes the **victim's** leaf.

The victim's coin remains in the DB but its leaf is gone from the header-committed accumulator, so it can never be spent again (proofs fail forever). Every node applies the identical diff, so the burn is permanent and global, for the cost of fees only. More generally this permanently desynchronizes the UTXO DB from the utreexo commitment.

## Fix

Before trusting an input, recompute the binding hash from the spent output and reject on mismatch (added to `prevalidate` and `validate`), via a new `Error::UtxoHashMismatch`.

## Test

`rejects_input_hash_not_matching_spent_output` builds a block that spends `outpoint_a` while citing `outpoint_b`'s leaf hash with a valid proof:

- with the fix: `prevalidate` returns `Err(UtxoHashMismatch { .. })` 
- with the check disabled: the input passes the loop, `accumulator.verify` and value conservation, failing only at the merkle-root check confirming the mismatch is otherwise undetected.