### PR TITLE
Reject spending withdrawal outputs in transactions

### DIFF
--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -162,6 +162,8 @@ pub enum Error {
     NotEnoughValueIn,
     #[error(transparent)]
     NoUtxo(#[from] NoUtxo),
+    #[error("withdrawal output {outpoint} cannot be spent by a transaction")]
+    SpendWithdrawalOutput { outpoint: OutPoint },
     #[error("Withdrawal bundle event block doesn't exist")]
     NoWithdrawalBundleEventBlock,
     #[error(transparent)]

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -358,7 +358,14 @@ impl State {
         let () = Self::validate_utxo_hashes(transaction)?;
         let mut value_in = bitcoin::Amount::ZERO;
         let mut value_out = bitcoin::Amount::ZERO;
-        for utxo in &transaction.spent_utxos {
+        for (outpoint, _, utxo) in transaction.inputs() {
+            // a withdrawal output is committed to a bundle and can only be
+            // spent by the bundle, never by a transaction
+            if utxo.content.is_withdrawal() {
+                return Err(Error::SpendWithdrawalOutput {
+                    outpoint: *outpoint,
+                });
+            }
             value_in = value_in
                 .checked_add(utxo.get_value())
                 .ok_or(AmountOverflowError)?;

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -600,11 +600,13 @@ impl Watchable<()> for State {
 
 #[cfg(test)]
 mod test {
+    use bitcoin::hashes::Hash as _;
+
     use crate::{
         state::State,
         types::{
-            Address, InPoint, OutPoint, OutPointKey, Output, OutputContent,
-            SpentOutput,
+            Address, FilledTransaction, InPoint, OutPoint, OutPointKey, Output,
+            OutputContent, PointedOutputRef, SpentOutput, Transaction, hash,
         },
     };
 
@@ -644,6 +646,46 @@ mod test {
             address: addr,
             content: OutputContent::Value(bitcoin::Amount::from_sat(sats)),
         }
+    }
+
+    #[test]
+    fn cannot_spend_withdrawal_output() -> anyhow::Result<()> {
+        let (_temp_dir, _env, state) =
+            fresh_state("cannot-spend-withdrawal-output")?;
+        let main_address = {
+            let pkh = bitcoin::PubkeyHash::hash(b"test pubkey");
+            bitcoin::Address::p2pkh(pkh, bitcoin::NetworkKind::Test)
+                .into_unchecked()
+        };
+        let withdrawal = Output {
+            address: Address::ALL_ZEROS,
+            content: OutputContent::Withdrawal {
+                value: bitcoin::Amount::from_sat(1000),
+                main_fee: bitcoin::Amount::from_sat(300),
+                main_address,
+            },
+        };
+        let outpoint = OutPoint::Regular {
+            txid: [1; 32].into(),
+            vout: 0,
+        };
+        let utxo_hash = hash(&PointedOutputRef {
+            outpoint,
+            output: &withdrawal,
+        });
+        let tx = FilledTransaction {
+            transaction: Transaction {
+                inputs: vec![(outpoint, utxo_hash)],
+                outputs: vec![value_output(Address::ALL_ZEROS, 1300)],
+                ..Default::default()
+            },
+            spent_utxos: vec![withdrawal],
+        };
+        assert!(matches!(
+            state.validate_filled_transaction(&tx),
+            Err(crate::state::Error::SpendWithdrawalOutput { .. })
+        ));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
A withdrawal output (`OutputContent::Withdrawal`) is created with the withdrawing user's own address and inserted into `state.utxos` + the utreexo accumulator like any output. When a withdrawal bundle is collected, `collect_withdrawal_bundle` only reads those UTXOs (via a read-only txn) to build the M6, stores the bundle as `Pending`, and the node broadcasts the M6 to the mainchain but the UTXOs are **not** removed from the set or the accumulator until the later `Submitted` event.

During that Pending - Submitted window the owner can spend the withdrawal output back to a `Value` output. Every consensus check passes: the utreexo leaf is still live, `validate_utxo_hashes` matches the real output's hash, `validate_filled_transaction` sees `value_in == value_out`, and authorization succeeds with the owner's key. Nothing rejected spending a `Withdrawal`-content output (`is_withdrawal()` was only used in wallet coin-selection).

Impact:

- **Double-spend / peg insolvency:** the M6 pays the value out on the mainchain treasury while the same value remains spendable on the sidechain.
- **Deterministic halt:** when the `Submitted` event later runs `if !state.utxos.delete(...) { return Err(NoUtxo) }`, the UTXO is already gone, so block connection fails for every node on deterministic 2WPD data.

## Fix

`validate_filled_transaction` now rejects any transaction input whose spent output is `Withdrawal`-content (`Error::SpendWithdrawalOutput`). A withdrawal output is committed to a bundle and can only be consumed by the bundle mechanism, never by a transaction which also guarantees the `Submitted` delete succeeds.