### PR TITLE
fix: P2P: block merkle roots not validated before inserting into archive DB

### DIFF
--- a/lib/archive.rs
+++ b/lib/archive.rs
@@ -20,6 +20,7 @@ use crate::types::{
 #[allow(clippy::duplicated_attributes)]
 #[derive(Debug, thiserror::Error, transitive::Transitive)]
 #[transitive(
+    from(db::error::Delete, DbError),
     from(db::error::Put, DbError),
     from(db::error::TryGet, DbError),
     from(env::error::CreateDb, EnvError)
@@ -728,6 +729,32 @@ impl Archive {
                 self.txid_to_inclusions.put(rwtxn, &txid, &inclusions)?;
                 Ok(())
             })
+    }
+
+    /// Delete a stored body, reversing the effects of [`Self::put_body`].
+    ///
+    /// Used to discard a body that was stored before its contents could be
+    /// validated (e.g. a body received from a peer) and later turned out to be
+    /// invalid, so that the block is reported missing again by
+    /// [`Self::iter_missing_bodies`] and the real body is re-requested.
+    pub fn delete_body(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+        body: &Body,
+    ) -> Result<(), Error> {
+        self.bodies.delete(rwtxn, &block_hash)?;
+        body.transactions.iter().try_for_each(|tx| {
+            let txid = tx.txid();
+            let mut inclusions = self.get_tx_inclusions(rwtxn, txid)?;
+            inclusions.remove(&block_hash);
+            if inclusions.is_empty() {
+                self.txid_to_inclusions.delete(rwtxn, &txid)?;
+            } else {
+                self.txid_to_inclusions.put(rwtxn, &txid, &inclusions)?;
+            }
+            Ok(())
+        })
     }
 
     /// Store a header.

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -19,7 +19,10 @@ use futures::{
     stream,
 };
 use nonempty::NonEmpty;
-use sneed::{DbError, EnvError, RwTxn, RwTxnError, db};
+use sneed::{
+    DbError, EnvError, RwTxn, RwTxnError, db, env::error as env_error,
+    rwtxn::error as rwtxn_error,
+};
 use thiserror::Error;
 use tokio::task::{self, JoinHandle};
 use tokio_stream::StreamNotifyClose;
@@ -43,8 +46,12 @@ use crate::{
 
 #[allow(clippy::duplicated_attributes)]
 #[derive(transitive::Transitive, Debug, Error)]
-#[transitive(from(db::error::IterInit, DbError))]
-#[transitive(from(db::error::IterItem, DbError))]
+#[transitive(
+    from(db::error::IterInit, DbError),
+    from(db::error::IterItem, DbError),
+    from(env_error::WriteTxn, EnvError),
+    from(rwtxn_error::Commit, RwTxnError)
+)]
 pub enum Error {
     #[error("archive error")]
     Archive(#[from] archive::Error),
@@ -386,7 +393,7 @@ fn reorg_to_tip(
             }
             two_way_peg_data
         };
-        let () = connect_tip_(
+        let () = match connect_tip_(
             &mut rwtxn,
             archive,
             mempool,
@@ -394,7 +401,27 @@ fn reorg_to_tip(
             &header,
             &body,
             &two_way_peg_data,
-        )?;
+        ) {
+            Ok(()) => (),
+            Err(err) => {
+                if is_fatal_reorg_error(&err) {
+                    // The stored body for this block failed validation (e.g. a peer
+                    // supplied a body whose contents do not match the header's merkle
+                    // root). Abort the reorg and discard the invalid body from the
+                    // archive so that the block is reported missing again and the real
+                    // body is re-requested, instead of the archive staying poisoned.
+                    drop(rwtxn);
+                    let mut rwtxn = env.write_txn()?;
+                    let () = archive.delete_body(
+                        &mut rwtxn,
+                        header.hash(),
+                        &body,
+                    )?;
+                    rwtxn.commit()?;
+                }
+                return Err(err);
+            }
+        };
         let new_tip_hash = state.try_get_tip(&rwtxn)?.unwrap();
         let bmm_verification =
             archive.get_best_main_verification(&rwtxn, new_tip_hash)?;
@@ -1027,7 +1054,7 @@ impl NetTask {
                                 "rejecting invalid tip from peer"
                             );
                             if let Some(addr) = addr {
-                                self.ctxt.net.remove_active_peer(addr);
+                                let () = self.ctxt.net.remove_active_peer(addr);
                             }
                             false
                         }


### PR DESCRIPTION
## Summary

Discard peer bodies that fail connect-time validation (new `Archive::delete_body`, called from `reorg_to_tip` on connect failure) and log+drop the peer instead of propagating the reorg error out of `NetTask::run`.

## The bug

P2P: block merkle roots not validated before inserting into archive DB

Severity: Medium. Full technical write-up (access-controlled): https://giaki3003.tech/#/findings/20260603-2200-thunder-peer-body-poison-archive-and-net-task-halt

## Notes

First of a short series of fixes for this repo from a security review; the remaining fixes stack on this branch and will follow as separate PRs. Happy to adjust scope or split further on request.