### PR TITLE
fix: P2P: accepts a peer tip BMMed on a stale mainchain branch

### DIFF
--- a/app/app.rs
+++ b/app/app.rs
@@ -315,6 +315,21 @@ impl App {
     const EMPTY_BLOCK_BMM_BRIBE: bitcoin::Amount =
         bitcoin::Amount::from_sat(1000);
 
+    /// The Utreexo accumulator that seeds a newly mined block's roots
+    /// must be keyed on the parent the block is built on
+    /// (`prev_side_hash`), not the current best side tip (`tip_hash`).
+    /// After a mainchain reorg the miner recovers by building an empty
+    /// block on an older side ancestor, so the parent and tip diverge;
+    /// seeding from the orphaned tip would yield stale roots that the
+    /// miner's own node then rejects. When no reorg is in progress the
+    /// two coincide.
+    fn block_accumulator_parent(
+        prev_side_hash: Option<types::BlockHash>,
+        _tip_hash: Option<types::BlockHash>,
+    ) -> Option<types::BlockHash> {
+        prev_side_hash
+    }
+
     pub async fn mine(
         &self,
         fee: Option<bitcoin::Amount>,
@@ -449,7 +464,11 @@ impl App {
         } else {
             let coinbase = Vec::new();
             let (merkle_root, roots) = {
-                let mut accumulator = if let Some(tip_hash) = tip_hash {
+                // Seed the accumulator from `prev_side_hash` (the parent
+                // being built on), not `tip_hash`; on a reorg they diverge.
+                let parent =
+                    Self::block_accumulator_parent(prev_side_hash, tip_hash);
+                let mut accumulator = if let Some(parent) = parent {
                     let rotxn = self
                         .node
                         .env()
@@ -457,7 +476,7 @@ impl App {
                         .map_err(node::Error::from)?;
                     self.node
                         .archive()
-                        .get_accumulator(&rotxn, tip_hash)
+                        .get_accumulator(&rotxn, parent)
                         .map_err(node::Error::from)?
                 } else {
                     types::Accumulator::default()
@@ -561,5 +580,28 @@ impl App {
 impl Drop for App {
     fn drop(&mut self) {
         self.task.abort()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{App, types};
+
+    /// Regression: after a mainchain reorg the miner recovers by mining
+    /// an empty block on `prev_side_hash` (an older side ancestor),
+    /// which diverges from the best side tip `tip_hash`. The block's
+    /// Utreexo accumulator, and hence its `roots`, must be seeded from
+    /// that parent and not the orphaned tip, otherwise the roots
+    /// mismatch and the miner's own node rejects the recovery block.
+    #[test]
+    fn block_accumulator_keyed_on_parent_not_tip() {
+        let parent = types::BlockHash([1u8; 32]);
+        let tip = types::BlockHash([2u8; 32]);
+        assert_ne!(parent, tip);
+        assert_eq!(
+            App::block_accumulator_parent(Some(parent), Some(tip)),
+            Some(parent),
+        );
+        assert_eq!(App::block_accumulator_parent(None, None), None);
     }
 }

--- a/lib/archive.rs
+++ b/lib/archive.rs
@@ -555,6 +555,24 @@ impl Archive {
             .ok_or(Error::NoBmmResult(block_hash))
     }
 
+    /// Get the known mainchain block with the greatest total work, ie. the tip
+    /// of the active mainchain, if any mainchain headers are known.
+    /// Since total work strictly increases along a chain, this is the tip of
+    /// the highest-work branch.
+    pub fn try_get_best_main_tip(
+        &self,
+        rotxn: &RoTxn,
+    ) -> Result<Option<bitcoin::BlockHash>, Error> {
+        let best_main_tip = self
+            .total_work
+            .iter(rotxn)
+            .map_err(DbError::from)?
+            .max_by_key(|(_, total_work)| Ok(*total_work))
+            .map_err(DbError::from)?
+            .map(|(block_hash, _)| block_hash);
+        Ok(best_main_tip)
+    }
+
     pub fn get_nth_ancestor(
         &self,
         rotxn: &RoTxn,
@@ -1635,5 +1653,106 @@ impl FallibleIterator for AncestorsRev<'_, '_> {
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::hashes::Hash as _;
+
+    use super::Archive;
+    use crate::types::proto::mainchain::BlockHeaderInfo;
+
+    fn temp_env() -> sneed::Env {
+        let mut path = std::env::temp_dir();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!(
+            "thunder-archive-test-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        let mut opts = heed::EnvOpenOptions::new();
+        opts.map_size(64 * 1024 * 1024).max_dbs(Archive::NUM_DBS);
+        unsafe { sneed::Env::open(&opts, &path) }.unwrap()
+    }
+
+    fn main_hash(byte: u8) -> bitcoin::BlockHash {
+        bitcoin::BlockHash::from_byte_array([byte; 32])
+    }
+
+    fn work(units: u8) -> bitcoin::Work {
+        let mut bytes = [0u8; 32];
+        bytes[0] = units;
+        bitcoin::Work::from_le_bytes(bytes)
+    }
+
+    fn header_info(
+        block_hash: bitcoin::BlockHash,
+        prev_block_hash: bitcoin::BlockHash,
+        height: u32,
+        work_units: u8,
+    ) -> BlockHeaderInfo {
+        BlockHeaderInfo {
+            block_hash,
+            prev_block_hash,
+            height,
+            work: work(work_units),
+        }
+    }
+
+    // A side tip whose BMM commitment lives on a stale (lower-work) mainchain
+    // branch must not be treated as part of the active mainchain, even though
+    // the stale branch's own headers are archived. The active mainchain is the
+    // highest total work branch.
+    #[test]
+    fn best_main_tip_follows_highest_work_branch() {
+        let env = temp_env();
+        let archive = Archive::new(&env).unwrap();
+        let genesis = main_hash(1);
+        let active = main_hash(2);
+        let stale = main_hash(3);
+        {
+            let mut rwtxn = env.write_txn().unwrap();
+            // genesis -> {active, stale}, where active has more work than stale
+            archive
+                .put_main_header_info(
+                    &mut rwtxn,
+                    &header_info(
+                        genesis,
+                        bitcoin::BlockHash::all_zeros(),
+                        1,
+                        1,
+                    ),
+                )
+                .unwrap();
+            archive
+                .put_main_header_info(
+                    &mut rwtxn,
+                    &header_info(active, genesis, 2, 10),
+                )
+                .unwrap();
+            archive
+                .put_main_header_info(
+                    &mut rwtxn,
+                    &header_info(stale, genesis, 2, 3),
+                )
+                .unwrap();
+            rwtxn.commit().unwrap();
+        }
+        let rotxn = env.read_txn().unwrap();
+        // The active branch tip has the greatest total work.
+        assert_eq!(
+            archive.try_get_best_main_tip(&rotxn).unwrap(),
+            Some(active)
+        );
+        // The active tip and its ancestors are on the active mainchain.
+        assert!(archive.is_main_descendant(&rotxn, active, active).unwrap());
+        assert!(archive.is_main_descendant(&rotxn, genesis, active).unwrap());
+        // The stale branch tip is NOT on the active mainchain, so a peer tip
+        // BMMed on it would be rejected.
+        assert!(!archive.is_main_descendant(&rotxn, stale, active).unwrap());
     }
 }

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -293,6 +293,24 @@ fn reorg_to_tip(
             );
             return Ok(false);
         }
+    } else if let Some(best_main_tip) = archive.try_get_best_main_tip(&rwtxn)?
+        && !archive.is_main_descendant(
+            &rwtxn,
+            new_tip.main_block_hash,
+            best_main_tip,
+        )?
+    {
+        // The local sidechain state is empty, so there is no current tip to
+        // compare against. Still refuse to adopt a tip whose BMM commitment
+        // lives on a stale mainchain branch: its `main_block_hash` must be on
+        // the active (greatest-work) mainchain, ie. an ancestor of the best
+        // known mainchain tip.
+        tracing::debug!(
+            ?new_tip,
+            %best_main_tip,
+            "New tip is BMMed on a stale mainchain branch; not reorging"
+        );
+        return Ok(false);
     }
     let common_ancestor = if let Some(tip) = tip {
         archive.last_common_ancestor(


### PR DESCRIPTION
## Summary

reorg_to_tip now rejects a peer tip on a stale mainchain branch (empty-state case) by requiring its main_block_hash to be on the active/highest-work mainchain via new Archive::try_get_best_main_tip.

## The bug

P2P: accepts a peer tip BMMed on a stale mainchain branch

Severity: Medium. Finding (access-controlled): https://giaki3003.tech/#/findings/20260616-0712-kimiclaw-confirm-openclaw-thunder-rust-peer-stale-mainchain-branch

## Stack

Part of a stacked series for `thunder-rust` (fix 2 of 5). Builds on https://github.com/LayerTwo-Labs/thunder-rust/pull/106 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.