### PR TITLE
fix: Mempool: not filtered correctly when connecting/disconnecting blocks

### DIFF
--- a/lib/mempool.rs
+++ b/lib/mempool.rs
@@ -153,6 +153,12 @@ impl MemPool {
     }
 
     /// regenerate utreexo proofs for all txs in the mempool
+    ///
+    /// A transaction whose inputs can no longer be proven against the
+    /// accumulator (eg. because they were spent by a just-connected block via
+    /// a conflicting transaction) is no longer valid. Such a transaction is
+    /// evicted from the mempool, along with its descendants, rather than
+    /// propagating an error that would abort block connect/disconnect.
     pub fn regenerate_proofs(
         &self,
         rwtxn: &mut RwTxn,
@@ -165,18 +171,36 @@ impl MemPool {
             .collect()
             .map_err(DbError::from)?;
         for txid in txids {
-            let mut tx =
-                self.transactions.get(rwtxn, &txid).map_err(DbError::from)?;
+            // The tx may already have been evicted as a descendant of an
+            // earlier invalidated tx.
+            let Some(mut tx) = self
+                .transactions
+                .try_get(rwtxn, &txid)
+                .map_err(DbError::from)?
+            else {
+                continue;
+            };
             let targets: Vec<_> = tx
                 .transaction
                 .inputs
                 .iter()
                 .map(|(_, utxo_hash)| utxo_hash.into())
                 .collect();
-            tx.transaction.proof = accumulator.prove(&targets)?;
-            self.transactions
-                .put(rwtxn, &txid, &tx)
-                .map_err(DbError::from)?;
+            match accumulator.prove(&targets) {
+                Ok(proof) => {
+                    tx.transaction.proof = proof;
+                    self.transactions
+                        .put(rwtxn, &txid, &tx)
+                        .map_err(DbError::from)?;
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        "evicting mempool transaction {txid}: inputs no \
+                         longer in accumulator"
+                    );
+                    let () = self.delete(rwtxn, txid)?;
+                }
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

`regenerate_proofs` now evicts (via `delete`) any mempool tx whose inputs can no longer be proven against the accumulator instead of returning a Utreexo error that aborts block connect/disconnect.

## The bug

Mempool: not filtered correctly when connecting/disconnecting blocks

Severity: Low. Finding (access-controlled): https://giaki3003.tech/#/findings/20260531-1755-thunder-mempool-regenerate-proofs-conflict-node-halt

## Stack

Part of a stacked series for `thunder-rust` (fix 4 of 5). Builds on https://github.com/LayerTwo-Labs/thunder-rust/pull/108 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.