### PR TITLE
fix: State: disconnect 2WPD sets incorrect event block

### DIFF
--- a/lib/state/two_way_peg_data.rs
+++ b/lib/state/two_way_peg_data.rs
@@ -982,7 +982,11 @@ fn disconnect_event(
             }
             let utxo_hash = hash(&PointedOutput { outpoint, output });
             accumulator_diff.remove(utxo_hash.into());
-            *latest_deposit_block_hash = Some(event_block_hash);
+            // Blocks are iterated in reverse here, so the first event block
+            // hash seen is the latest. Keep it to match what `connect` stored.
+            if latest_deposit_block_hash.is_none() {
+                *latest_deposit_block_hash = Some(event_block_hash);
+            }
         }
         BlockEvent::WithdrawalBundle(withdrawal_bundle_event) => {
             let () = disconnect_withdrawal_bundle_event(
@@ -992,7 +996,12 @@ fn disconnect_event(
                 accumulator_diff,
                 withdrawal_bundle_event,
             )?;
-            *latest_withdrawal_bundle_event_block_hash = Some(event_block_hash);
+            // Blocks are iterated in reverse here, so the first event block
+            // hash seen is the latest. Keep it to match what `connect` stored.
+            if latest_withdrawal_bundle_event_block_hash.is_none() {
+                *latest_withdrawal_bundle_event_block_hash =
+                    Some(event_block_hash);
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

disconnect_event now keeps the first (latest) event-block hash seen during reverse iteration for both deposit and withdrawal-bundle events, matching connect's stored value instead of overwriting down to the earliest block.

## The bug

State: disconnect 2WPD sets incorrect event block

Severity: Low. Finding (access-controlled): 

## Stack

Part of a stacked series for `thunder-rust` (fix 5 of 5). Builds on https://github.com/LayerTwo-Labs/thunder-rust/pull/109 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.