### PR TITLE
RPC: add get_block_template/connect_block methods

### DIFF
--- a/app/app.rs
+++ b/app/app.rs
@@ -94,6 +94,16 @@ struct ProtoSupport {
     wallet: bool,
 }
 
+/// A block that is ready to be blind merged mined
+pub struct BlockTemplate {
+    /// Bribe to offer for this block
+    pub bribe: bitcoin::Amount,
+    pub header: types::Header,
+    pub body: types::Body,
+    /// Fees collected by the transactions in the block
+    pub fees: bitcoin::Amount,
+}
+
 #[derive(Clone)]
 pub struct App {
     pub node: Arc<Node>,
@@ -354,10 +364,11 @@ impl App {
     const EMPTY_BLOCK_BMM_BRIBE: bitcoin::Amount =
         bitcoin::Amount::from_sat(1000);
 
-    pub async fn mine(
+    /// Assemble a block to blind merge mine, without requesting BMM for it
+    async fn build_block_template(
         &self,
         fee: Option<bitcoin::Amount>,
-    ) -> Result<(), Error> {
+    ) -> Result<BlockTemplate, Error> {
         let Some(miner) = self.miner.as_ref() else {
             return Err(Error::NoCusfMainchainWalletClient);
         };
@@ -429,7 +440,7 @@ impl App {
         } else {
             None
         };
-        let (bribe, header, body) = if prev_side_hash == tip_hash {
+        let (bribe, header, body, fees) = if prev_side_hash == tip_hash {
             const NUM_TRANSACTIONS: usize = 1000;
             let (txs, tx_fees) =
                 self.node.get_transactions(NUM_TRANSACTIONS)?;
@@ -484,7 +495,7 @@ impl App {
                     Self::EMPTY_BLOCK_BMM_BRIBE
                 }
             });
-            (bribe, header, body)
+            (bribe, header, body, tx_fees)
         } else {
             let coinbase = Vec::new();
             let (merkle_root, roots) = {
@@ -523,8 +534,55 @@ impl App {
                 prev_main_hash,
             };
             let bribe = Self::EMPTY_BLOCK_BMM_BRIBE;
-            (bribe, header, body)
+            (bribe, header, body, bitcoin::Amount::ZERO)
         };
+        Ok(BlockTemplate {
+            bribe,
+            header,
+            body,
+            fees,
+        })
+    }
+
+    /// Assemble a block to blind merge mine. The caller requests BMM for
+    /// `header.hash()` itself, and submits the block via `connect_block` once
+    /// its BMM request is included in a mainchain block.
+    pub async fn get_block_template(&self) -> Result<BlockTemplate, Error> {
+        self.build_block_template(None).await
+    }
+
+    /// Connect a block for which a BMM request was included in the specified
+    /// mainchain block. Returns `true` if it was accepted as the new tip.
+    pub async fn connect_block(
+        &self,
+        block: types::Block,
+        main_block_hash: bitcoin::BlockHash,
+    ) -> Result<bool, Error> {
+        let types::Block { header, body } = block;
+        let accepted = self
+            .node
+            .submit_block(main_block_hash, &header, &body)
+            .await?;
+        if accepted {
+            let () = self.update()?;
+        }
+        Ok(accepted)
+    }
+
+    /// Attempt to mine a sidechain block
+    pub async fn mine(
+        &self,
+        fee: Option<bitcoin::Amount>,
+    ) -> Result<(), Error> {
+        let Some(miner) = self.miner.as_ref() else {
+            return Err(Error::NoCusfMainchainWalletClient);
+        };
+        let BlockTemplate {
+            bribe,
+            header,
+            body,
+            ..
+        } = self.build_block_template(fee).await?;
         let mut miner_write = miner.write().await;
         let bmm_txid = miner_write
             .attempt_bmm(bribe.to_sat(), 0, header, body)

--- a/app/rpc_server.rs
+++ b/app/rpc_server.rs
@@ -7,8 +7,8 @@ use jsonrpsee::{
     types::ErrorObject,
 };
 use thunder::types::{
-    Address, Pointed, PointedOutput, SpentOutput, Txid, WithdrawalBundle,
-    net::Peer, wallet::Balance,
+    Address, Block, Pointed, PointedOutput, SpentOutput, Txid,
+    WithdrawalBundle, net::Peer, wallet::Balance,
 };
 use thunder_app_rpc_api as rpc_api;
 use tower_http::{
@@ -100,6 +100,25 @@ impl rpc_api::node::PrivateRpcServer for RpcServerImpl<true> {
 impl<const ENABLE_PRIVATE_API: bool> rpc_api::node::RpcServer
     for RpcServerImpl<ENABLE_PRIVATE_API>
 {
+    async fn connect_block(
+        &self,
+        block: Block,
+        main_block_hash: bitcoin::BlockHash,
+    ) -> RpcResult<bool> {
+        self.app
+            .local_pool
+            .spawn_pinned({
+                let app = self.app.clone();
+                move || async move {
+                    app.connect_block(block, main_block_hash)
+                        .await
+                        .map_err(custom_err)
+                }
+            })
+            .await
+            .unwrap()
+    }
+
     async fn get_block(
         &self,
         block_hash: thunder::types::BlockHash,
@@ -340,6 +359,30 @@ impl rpc_api::wallet::RpcServer for RpcServerImpl<true> {
             bip39::Language::English,
         );
         Ok(mnemonic.to_string())
+    }
+
+    async fn get_block_template(
+        &self,
+    ) -> RpcResult<rpc_api::wallet::GetBlockTemplateResponse> {
+        let template = self
+            .app
+            .local_pool
+            .spawn_pinned({
+                let app = self.app.clone();
+                move || async move {
+                    app.get_block_template().await.map_err(custom_err)
+                }
+            })
+            .await
+            .unwrap()?;
+        Ok(rpc_api::wallet::GetBlockTemplateResponse {
+            critical_hash: template.header.hash(),
+            block: Block {
+                header: template.header,
+                body: template.body,
+            },
+            fees_sats: template.fees.to_sat(),
+        })
     }
 
     async fn get_new_address(&self) -> RpcResult<Address> {

--- a/cli/lib.rs
+++ b/cli/lib.rs
@@ -30,6 +30,12 @@ impl<T> JsonParser<T> {
 pub enum Command {
     /// Get balance in sats
     Balance,
+    /// Connect a block for which a BMM request was included in the specified
+    /// mainchain block. The block is the JSON returned by `get-block-template`.
+    ConnectBlock {
+        block: String,
+        main_block_hash: bitcoin::BlockHash,
+    },
     /// Connect to a peer
     ConnectPeer { addr: SocketAddr },
     /// Deposit to address
@@ -74,6 +80,8 @@ pub enum Command {
     GetBlock {
         block_hash: thunder::types::BlockHash,
     },
+    /// Assemble a block to blind merge mine, without requesting BMM for it
+    GetBlockTemplate,
     /// Get mainchain blocks that commit to a specified block hash
     GetBmmInclusions {
         block_hash: thunder::types::BlockHash,
@@ -168,6 +176,15 @@ where
             let balance = rpc_client.balance().await?;
             serde_json::to_string_pretty(&balance)?
         }
+        Command::ConnectBlock {
+            block,
+            main_block_hash,
+        } => {
+            let block = serde_json::from_str(&block)?;
+            let accepted =
+                rpc_client.connect_block(block, main_block_hash).await?;
+            format!("{accepted}")
+        }
         Command::ConnectPeer { addr } => {
             let () = rpc_client.connect_peer(addr).await?;
             String::default()
@@ -226,6 +243,10 @@ where
         Command::GetBestSidechainBlockHash => {
             let block_hash = rpc_client.get_best_sidechain_block_hash().await?;
             serde_json::to_string_pretty(&block_hash)?
+        }
+        Command::GetBlockTemplate => {
+            let template = rpc_client.get_block_template().await?;
+            serde_json::to_string_pretty(&template)?
         }
         Command::GetBmmInclusions { block_hash } => {
             let bmm_inclusions =

--- a/integration_tests/block_template.rs
+++ b/integration_tests/block_template.rs
@@ -1,0 +1,155 @@
+//! Test assembling block templates
+
+use bip300301_enforcer_integration_tests::{
+    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
+    setup::{
+        Mode, Network, PostSetup as EnforcerPostSetup,
+        PreSetup as EnforcerPreSetup, SetupOpts as EnforcerSetupOpts,
+        Sidechain as _,
+    },
+    util::{
+        AbortOnDrop, AsyncTrial, BinPaths as EnforcerBinPaths,
+        TestFailureCollector, TestFileRegistry,
+    },
+};
+use futures::{
+    FutureExt as _, StreamExt as _, channel::mpsc, future::BoxFuture,
+};
+use thunder_app_rpc_api::{node::RpcClient as _, wallet::RpcClient as _};
+use tokio::time::sleep;
+use tracing::Instrument as _;
+
+use crate::{
+    setup::{Init, PostSetup},
+    util::BinPaths,
+};
+
+/// Initial setup for the test
+async fn setup(
+    enforcer_bin_paths: &EnforcerBinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<EnforcerPostSetup> {
+    let enforcer_pre_setup =
+        EnforcerPreSetup::new(enforcer_bin_paths, Network::Regtest)?;
+    let mut enforcer_post_setup = {
+        let setup_opts: EnforcerSetupOpts = Default::default();
+        enforcer_pre_setup
+            .setup(Mode::Mempool, setup_opts, res_tx.clone())
+            .await?
+    };
+    let () = propose_sidechain::<PostSetup>(&mut enforcer_post_setup).await?;
+    tracing::info!("Proposed sidechain successfully");
+    let () = activate_sidechain::<PostSetup>(&mut enforcer_post_setup).await?;
+    tracing::info!("Activated sidechain successfully");
+    let () = fund_enforcer::<PostSetup>(&mut enforcer_post_setup).await?;
+    Ok(enforcer_post_setup)
+}
+
+async fn block_template_task(
+    bin_paths: BinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let mut enforcer_post_setup =
+        setup(&bin_paths.others, res_tx.clone()).await?;
+    let sidechain = PostSetup::setup(
+        Init {
+            thunder_app: bin_paths.thunder()?.clone(),
+            data_dir_suffix: None,
+        },
+        &enforcer_post_setup,
+        res_tx,
+    )
+    .await?;
+    tracing::info!("Setup thunder node successfully");
+
+    tracing::debug!("Checking that the first template is empty");
+    let template = sidechain.rpc_client.get_block_template().await?;
+    anyhow::ensure!(template.block.header.prev_side_hash.is_none());
+    anyhow::ensure!(template.block.body.transactions.is_empty());
+    anyhow::ensure!(template.fees_sats == 0);
+
+    tracing::debug!("Checking that a template is stable while the chain is");
+    let template_repeat = sidechain.rpc_client.get_block_template().await?;
+    anyhow::ensure!(template_repeat.critical_hash == template.critical_hash);
+
+    tracing::debug!("Checking that a template is not connected by itself");
+    anyhow::ensure!(sidechain.rpc_client.getblockcount().await? == 0);
+
+    tracing::debug!("BMM 1 block");
+    let () = sidechain.bmm_single(&mut enforcer_post_setup).await?;
+    anyhow::ensure!(sidechain.rpc_client.getblockcount().await? == 1);
+
+    tracing::debug!("Checking that a template builds on the new tips");
+    let template_connected = sidechain.rpc_client.get_block_template().await?;
+    let best_side_hash =
+        sidechain.rpc_client.get_best_sidechain_block_hash().await?;
+    let best_main_hash =
+        sidechain.rpc_client.get_best_mainchain_block_hash().await?;
+    anyhow::ensure!(best_side_hash.is_some());
+    anyhow::ensure!(
+        template_connected.block.header.prev_side_hash == best_side_hash
+    );
+    anyhow::ensure!(
+        Some(template_connected.block.header.prev_main_hash) == best_main_hash
+    );
+    anyhow::ensure!(
+        template_connected.critical_hash != template_repeat.critical_hash
+    );
+
+    tracing::debug!("Checking that a template commits to its own block");
+    anyhow::ensure!(
+        template_connected.block.header.hash()
+            == template_connected.critical_hash
+    );
+
+    tracing::debug!("Checking that a block without BMM is not connected");
+    let connect_without_bmm = sidechain
+        .rpc_client
+        .connect_block(
+            template_connected.block.clone(),
+            template_connected.block.header.prev_main_hash,
+        )
+        .await;
+    anyhow::ensure!(matches!(connect_without_bmm, Err(_) | Ok(false)));
+    anyhow::ensure!(sidechain.rpc_client.getblockcount().await? == 1);
+
+    drop(sidechain);
+    tracing::info!(
+        "Removing {}",
+        enforcer_post_setup.directories.base_dir.path().display()
+    );
+    drop(enforcer_post_setup.tasks);
+    // Wait for tasks to die
+    sleep(std::time::Duration::from_secs(1)).await;
+    enforcer_post_setup.directories.base_dir.cleanup()?;
+    Ok(())
+}
+
+async fn block_template(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, mut res_rx) = mpsc::unbounded();
+    let _test_task: AbortOnDrop<()> = tokio::task::spawn({
+        let res_tx = res_tx.clone();
+        async move {
+            let res = block_template_task(bin_paths, res_tx.clone()).await;
+            let _send_err: Result<(), _> = res_tx.unbounded_send(res);
+        }
+        .in_current_span()
+    })
+    .into();
+    res_rx.next().await.ok_or_else(|| {
+        anyhow::anyhow!("Unexpected end of test task result stream")
+    })?
+}
+
+pub fn block_template_trial(
+    bin_paths: BinPaths,
+    file_registry: TestFileRegistry,
+    failure_collector: TestFailureCollector,
+) -> AsyncTrial<BoxFuture<'static, anyhow::Result<()>>> {
+    AsyncTrial::new(
+        "block_template",
+        block_template(bin_paths).boxed(),
+        file_registry,
+        failure_collector,
+    )
+}

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -12,6 +12,7 @@ use futures::{FutureExt, channel::mpsc::UnboundedSender, future::BoxFuture};
 use thunder_app_rpc_api::node::RpcClient as _;
 
 use crate::{
+    block_template::block_template_trial,
     ibd::ibd_trial,
     setup::{Init, PostSetup},
     unknown_withdrawal::unknown_withdrawal_trial,
@@ -162,6 +163,11 @@ pub fn tests(
     failure_collector: TestFailureCollector,
 ) -> Vec<AsyncTrial<BoxFuture<'static, anyhow::Result<()>>>> {
     vec![
+        block_template_trial(
+            bin_paths.clone(),
+            file_registry.clone(),
+            failure_collector.clone(),
+        ),
         deposit_withdraw_roundtrip_trial(
             bin_paths.clone(),
             file_registry.clone(),

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -4,6 +4,7 @@ use bip300301_enforcer_integration_tests::util::{
 use clap::Parser;
 use tracing_subscriber::{filter as tracing_filter, layer::SubscriberExt};
 
+mod block_template;
 mod ibd;
 mod integration_test;
 mod setup;

--- a/rpc-api/lib.rs
+++ b/rpc-api/lib.rs
@@ -25,7 +25,7 @@ pub mod node {
     use l2l_openapi::open_api;
     use serde::{Deserialize, Serialize};
     use thunder_types::{
-        Address, Authorized, BlockHash, MerkleRoot, OutPoint, Output,
+        Address, Authorized, Block, BlockHash, MerkleRoot, OutPoint, Output,
         OutputContent, Pointed, PointedOutput, SpentOutput, Transaction, Txid,
         WithdrawalBundle, net::Peer, schema as thunder_schema,
     };
@@ -86,6 +86,20 @@ pub mod node {
     ])]
     #[rpc(client, server, server_bounds(Self: open_api::RpcServer))]
     pub trait Rpc {
+        /// Connect a block template for which a BMM request was included in the
+        /// specified mainchain block. Returns `true` if it was accepted as the new
+        /// tip.
+        #[open_api_method(output_schema(ToSchema))]
+        #[method(name = "connect_block")]
+        async fn connect_block(
+            &self,
+            block: Block,
+            #[open_api_method_arg(schema(
+                PartialSchema = "thunder_schema::BitcoinBlockHash"
+            ))]
+            main_block_hash: bitcoin::BlockHash,
+        ) -> RpcResult<bool>;
+
         /// Get the block with specified block hash, if it exists
         #[method(name = "get_block")]
         async fn get_block(
@@ -183,13 +197,26 @@ pub mod node {
 pub mod wallet {
     use jsonrpsee::{core::RpcResult, proc_macros::rpc};
     use l2l_openapi::open_api;
+    use serde::{Deserialize, Serialize};
     use thunder_types::{
-        Address, Authorized, MerkleRoot, OutPoint, Output, OutputContent,
-        PointedOutput, Transaction, Txid, schema as thunder_schema,
-        wallet::Balance,
+        Address, Authorized, Block, BlockHash, MerkleRoot, OutPoint, Output,
+        OutputContent, PointedOutput, Transaction, Txid,
+        schema as thunder_schema, wallet::Balance,
     };
+    use utoipa::ToSchema;
 
     use crate::{open_api, schema};
+
+    #[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+    pub struct GetBlockTemplateResponse {
+        /// Block hash to commit to in a BMM request
+        pub critical_hash: BlockHash,
+        /// Block to pass to `connect_block` once its BMM request is included in a
+        /// mainchain block
+        pub block: Block,
+        /// Fees collected by the transactions in the block, in sats
+        pub fees_sats: u64,
+    }
 
     #[open_api(ref_schemas[
         Address, MerkleRoot, OutPoint, Output, OutputContent, Txid,
@@ -250,6 +277,15 @@ pub mod wallet {
         /// Generate a mnemonic seed phrase
         #[method(name = "generate_mnemonic")]
         async fn generate_mnemonic(&self) -> RpcResult<String>;
+
+        /// Assemble a block to blind merge mine, without requesting BMM for it.
+        /// The caller requests BMM for `critical_hash` itself, then passes the
+        /// block back to `connect_block`.
+        #[open_api_method(output_schema(ToSchema))]
+        #[method(name = "get_block_template")]
+        async fn get_block_template(
+            &self,
+        ) -> RpcResult<GetBlockTemplateResponse>;
 
         /// Get a new address
         #[method(name = "get_new_address")]


### PR DESCRIPTION
Splits block assembly out of `mine`, so that a caller can request BMM for a template itself and submit the block via `connect_block` once its request is included in a mainchain block. `mine` keeps its existing behaviour, including the bribe it picks when no fee is given.

The integration test covers template assembly, and that a block without a BMM request is refused. Connecting a block whose BMM request the caller made is not covered, since the test harness only exposes `mine`.