### PR TITLE
net: resolve seed names by host name, add as CLI opt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6432,6 +6432,7 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "transitive",
+ "url",
 ]
 
 [[package]]
@@ -7128,6 +7129,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/app/app.rs
+++ b/app/app.rs
@@ -282,6 +282,7 @@ impl App {
                 bind_addr: config.net_addr,
                 magic_bytes_override: config.network_magic_override,
                 network: config.network,
+                seed_nodes: &config.seed_nodes,
             },
             cusf_mainchain,
             cusf_mainchain_wallet,

--- a/app/app.rs
+++ b/app/app.rs
@@ -277,12 +277,14 @@ impl App {
 
         tracing::debug!("Instantiating node struct");
         let node = Node::new(
-            &config.datadir,
-            config.net_addr,
+            thunder::node::Config {
+                datadir: &config.datadir,
+                bind_addr: config.net_addr,
+                magic_bytes_override: config.network_magic_override,
+                network: config.network,
+            },
             cusf_mainchain,
             cusf_mainchain_wallet,
-            config.network_magic_override,
-            config.network,
             &runtime,
         )?;
         let utxos = {

--- a/app/cli.rs
+++ b/app/cli.rs
@@ -147,6 +147,11 @@ pub(super) struct Cli {
     /// Socket address to host the RPC server
     #[arg(default_value_t = DEFAULT_RPC_ADDR, long, short)]
     rpc_addr: SocketAddr,
+    /// Additional seed node to dial on startup, as `host:port`. May be given
+    /// more than once, and is dialed in addition to the network's built-in seed
+    /// nodes.
+    #[arg(long = "seed-node")]
+    seed_nodes: Vec<thunder::net::PeerAddress>,
 }
 
 #[derive(Clone, Debug)]
@@ -164,6 +169,7 @@ pub struct Config {
     pub network_magic_override: Option<thunder::net::peer_message::MagicBytes>,
     pub private_rpc_addr: SocketAddr,
     pub rpc_addr: SocketAddr,
+    pub seed_nodes: Vec<thunder::net::PeerAddress>,
 }
 
 impl Cli {
@@ -202,6 +208,7 @@ impl Cli {
             network_magic_override: self.network_magic,
             private_rpc_addr: self.private_rpc_addr,
             rpc_addr: self.rpc_addr,
+            seed_nodes: self.seed_nodes,
         })
     }
 }

--- a/integration_tests/block_template.rs
+++ b/integration_tests/block_template.rs
@@ -52,10 +52,7 @@ async fn block_template_task(
     let mut enforcer_post_setup =
         setup(&bin_paths.others, res_tx.clone()).await?;
     let sidechain = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: None,
-        },
+        Init::new(bin_paths.thunder()?.clone(), None),
         &enforcer_post_setup,
         res_tx,
     )

--- a/integration_tests/ibd.rs
+++ b/integration_tests/ibd.rs
@@ -43,20 +43,14 @@ async fn setup(
             .await?
     };
     let sidechain_sender = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("sender".to_owned()),
-        },
+        Init::new(bin_paths.thunder()?.clone(), Some("sender")),
         &enforcer_post_setup,
         res_tx.clone(),
     )
     .await?;
     tracing::info!("Setup thunder send node successfully");
     let sidechain_syncer = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("syncer".to_owned()),
-        },
+        Init::new(bin_paths.thunder()?.clone(), Some("syncer")),
         &enforcer_post_setup,
         res_tx,
     )

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -14,7 +14,7 @@ use thunder_app_rpc_api::node::RpcClient as _;
 use crate::{
     block_template::block_template_trial,
     ibd::ibd_trial,
-    peer_persistence::peer_persistence_trial,
+    peer_persistence::{peer_persistence_trial, seed_node_resolution_trial},
     setup::{Init, PostSetup},
     unknown_withdrawal::unknown_withdrawal_trial,
     util::BinPaths,
@@ -144,10 +144,7 @@ fn deposit_withdraw_roundtrip_trial(
             };
             deposit_withdraw_roundtrip(
                 post_setup,
-                Init {
-                    thunder_app: bin_paths.thunder()?.clone(),
-                    data_dir_suffix: None,
-                },
+                Init::new(bin_paths.thunder()?.clone(), None),
                 res_tx,
             )
             .await
@@ -180,6 +177,11 @@ pub fn tests(
             failure_collector.clone(),
         ),
         peer_persistence_trial(
+            bin_paths.clone(),
+            file_registry.clone(),
+            failure_collector.clone(),
+        ),
+        seed_node_resolution_trial(
             bin_paths.clone(),
             file_registry.clone(),
             failure_collector.clone(),

--- a/integration_tests/integration_test.rs
+++ b/integration_tests/integration_test.rs
@@ -14,6 +14,7 @@ use thunder_app_rpc_api::node::RpcClient as _;
 use crate::{
     block_template::block_template_trial,
     ibd::ibd_trial,
+    peer_persistence::peer_persistence_trial,
     setup::{Init, PostSetup},
     unknown_withdrawal::unknown_withdrawal_trial,
     util::BinPaths,
@@ -174,6 +175,11 @@ pub fn tests(
             failure_collector.clone(),
         ),
         ibd_trial(
+            bin_paths.clone(),
+            file_registry.clone(),
+            failure_collector.clone(),
+        ),
+        peer_persistence_trial(
             bin_paths.clone(),
             file_registry.clone(),
             failure_collector.clone(),

--- a/integration_tests/main.rs
+++ b/integration_tests/main.rs
@@ -7,6 +7,7 @@ use tracing_subscriber::{filter as tracing_filter, layer::SubscriberExt};
 mod block_template;
 mod ibd;
 mod integration_test;
+mod peer_persistence;
 mod setup;
 mod unknown_withdrawal;
 mod util;

--- a/integration_tests/peer_persistence.rs
+++ b/integration_tests/peer_persistence.rs
@@ -117,11 +117,19 @@ async fn wait_for_log(
     }
 }
 
-/// Two thunder nodes against a single enforcer.
-async fn setup(
+/// Two thunder nodes against a single enforcer. `peer_init` may adjust the
+/// first node's setup; `node_init` the second's, and is also passed the
+/// first node's P2P port -- not known until it is set up.
+async fn setup_with_args<P, F>(
     bin_paths: BinPaths,
     res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
-) -> anyhow::Result<(EnforcerPostSetup, PostSetup, PostSetup)> {
+    peer_init: P,
+    node_init: F,
+) -> anyhow::Result<(EnforcerPostSetup, PostSetup, PostSetup)>
+where
+    P: FnOnce(Init) -> Init,
+    F: FnOnce(Init, u16) -> Init,
+{
     let enforcer_pre_setup =
         EnforcerPreSetup::new(&bin_paths.others, Network::Regtest)?;
     let mut enforcer_post_setup = {
@@ -131,19 +139,17 @@ async fn setup(
             .await?
     };
     let peer = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("peer".to_owned()),
-        },
+        peer_init(Init::new(bin_paths.thunder()?.clone(), Some("peer"))),
         &enforcer_post_setup,
         res_tx.clone(),
     )
     .await?;
+    // Started second, so the first is listening when its seeds are dialed.
     let node = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("node".to_owned()),
-        },
+        node_init(
+            Init::new(bin_paths.thunder()?.clone(), Some("node")),
+            peer.net_port(),
+        ),
         &enforcer_post_setup,
         res_tx,
     )
@@ -152,6 +158,128 @@ async fn setup(
     let () = activate_sidechain::<PostSetup>(&mut enforcer_post_setup).await?;
     let () = fund_enforcer::<PostSetup>(&mut enforcer_post_setup).await?;
     Ok((enforcer_post_setup, peer, node))
+}
+
+/// Initial setup: two thunder nodes against a single enforcer.
+async fn setup(
+    bin_paths: BinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<(EnforcerPostSetup, PostSetup, PostSetup)> {
+    setup_with_args(bin_paths, res_tx, |init| init, |init, _| init).await
+}
+
+/// Active connections `node` holds to `port` on either loopback address.
+async fn loopback_conns_to_port(
+    node: &PostSetup,
+    port: u16,
+) -> anyhow::Result<Vec<SocketAddr>> {
+    let conns = peer_addrs(node)
+        .await?
+        .into_iter()
+        .filter(|addr| addr.ip().is_loopback() && addr.port() == port)
+        .collect();
+    Ok(conns)
+}
+
+/// A hostname seed is resolved on startup and dialed, with no `connect_peer`,
+/// and a host that resolves to several addresses gets exactly one connection.
+///
+/// `localhost` resolves from the hosts file on every supported platform, so
+/// this exercises the real resolver without needing network access or an
+/// external zone. A numeric address would not distinguish resolution from
+/// parsing. Both nodes bind dual-stack, so the peer is reachable at both of
+/// `localhost`'s addresses; dialing every resolved address instead of trying
+/// them one at a time would thus connect twice.
+async fn seed_node_resolution_task(
+    bin_paths: BinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    // Loopback with nothing bound, reserved so nothing else can answer. Its
+    // dials fail no matter which of `localhost`'s addresses is tried, so the
+    // node must walk through all of them and report exhaustion.
+    let dead_port = reserve_port::ReservedPort::random()?;
+    let (enforcer_post_setup, peer, node) = setup_with_args(
+        bin_paths,
+        res_tx,
+        // Bound dual-stack, so it is reachable at both of `localhost`'s
+        // addresses
+        |init| init.with_net_host("[::]"),
+        // Also bound dual-stack: an IPv4-bound QUIC endpoint cannot dial
+        // `::1` at all, which would leave only one usable address per host
+        // and nothing for the single-connection check below to detect
+        |init, peer_port| {
+            init.with_net_host("[::]").with_extra_args([
+                "--seed-node".to_owned(),
+                format!("localhost:{peer_port}"),
+                "--seed-node".to_owned(),
+                format!("localhost:{}", dead_port.port()),
+            ])
+        },
+    )
+    .await?;
+    let peer_port = peer.net_port();
+
+    tracing::info!(
+        %peer_port,
+        "Waiting for the node to reach its seed node by hostname"
+    );
+    // Seed resolution runs in the background, so may not be done when RPC is
+    // up. The connection may use either loopback address, depending on
+    // resolution order, so it is awaited by port. Waiting on the validation
+    // makes the connection count below final: once a connection to the seed
+    // has validated, its other addresses are never dialed.
+    let () = wait_for_log(
+        &node,
+        "the seed node to be validated",
+        &["peer validated", &format!("localhost:{peer_port}")],
+        WAIT_TIMEOUT,
+    )
+    .await?;
+    // Give a second dial time to land, were one ever issued; the addresses
+    // of a peer are dialed within moments of each other.
+    sleep(Duration::from_secs(1)).await;
+    let conns = loopback_conns_to_port(&node, peer_port).await?;
+    anyhow::ensure!(
+        conns.len() == 1,
+        "the node should hold exactly one connection to its seed node, \
+         found {conns:?}"
+    );
+    // A real peering, not just a half-open dial recorded locally.
+    let peer_side = peer_addrs(&peer).await?;
+    anyhow::ensure!(
+        peer_side.len() == 1,
+        "peer should have accepted exactly one connection from the node, \
+         found {peer_side:?}"
+    );
+
+    // The dead seed's addresses are tried one at a time, each dial failing,
+    // until none remain. Each attempt takes a full 30s handshake timeout:
+    // nothing answers, and ICMP unreachable does not cancel a QUIC dial. The
+    // dials began at node startup, so some of that has already passed, but
+    // the wait must still cover most of two timeouts.
+    const EXHAUSTION_TIMEOUT: Duration = Duration::from_secs(90);
+    let () = wait_for_log(
+        &node,
+        "the dead seed node's addresses to be exhausted",
+        &[
+            "no more addresses to try",
+            &format!("localhost:{}", dead_port.port()),
+        ],
+        EXHAUSTION_TIMEOUT,
+    )
+    .await?;
+
+    drop(node);
+    drop(peer);
+    drop(dead_port);
+    tracing::info!(
+        "Removing {}",
+        enforcer_post_setup.directories.base_dir.path().display()
+    );
+    drop(enforcer_post_setup.tasks);
+    sleep(Duration::from_secs(1)).await;
+    enforcer_post_setup.directories.base_dir.cleanup()?;
+    Ok(())
 }
 
 /// A peer that completes a handshake is remembered across a restart; one that
@@ -206,10 +334,12 @@ async fn peer_persistence_task(
 
     // Validated before the restart, so written to `known_peers` and re-dialed.
     let () = wait_for_peer(&node, peer_addr).await?;
+    // Startup dials are issued by the net task in one batch, but only
+    // near-simultaneously. Give it a moment, so that absence below means
+    // "not persisted", not "not dialed yet".
+    sleep(Duration::from_secs(1)).await;
     let addrs = peer_addrs(&node).await?;
-    // Never sent a message, so never validated, so never persisted. Both dials
-    // are issued by `Net::new` before the RPC server answers, so had it been
-    // persisted it would already be listed alongside the live peer.
+    // Never sent a message, so never validated, so never persisted.
     anyhow::ensure!(
         !addrs.contains(&unreachable_addr),
         "unreachable peer at {unreachable_addr} was never validated and must \
@@ -244,6 +374,36 @@ async fn peer_persistence(bin_paths: BinPaths) -> anyhow::Result<()> {
     res_rx.next().await.ok_or_else(|| {
         anyhow::anyhow!("Unexpected end of test result stream")
     })?
+}
+
+async fn seed_node_resolution(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, mut res_rx) = mpsc::unbounded();
+    let _test_task: AbortOnDrop<()> = tokio::task::spawn({
+        let res_tx = res_tx.clone();
+        async move {
+            let res =
+                seed_node_resolution_task(bin_paths, res_tx.clone()).await;
+            let _send_err: Result<(), _> = res_tx.unbounded_send(res);
+        }
+        .in_current_span()
+    })
+    .into();
+    res_rx.next().await.ok_or_else(|| {
+        anyhow::anyhow!("Unexpected end of test result stream")
+    })?
+}
+
+pub fn seed_node_resolution_trial(
+    bin_paths: BinPaths,
+    file_registry: TestFileRegistry,
+    failure_collector: TestFailureCollector,
+) -> AsyncTrial<BoxFuture<'static, anyhow::Result<()>>> {
+    AsyncTrial::new(
+        "seed_node_resolution",
+        seed_node_resolution(bin_paths).boxed(),
+        file_registry,
+        failure_collector,
+    )
 }
 
 pub fn peer_persistence_trial(

--- a/integration_tests/peer_persistence.rs
+++ b/integration_tests/peer_persistence.rs
@@ -1,0 +1,260 @@
+//! Tests for which peers are written to the `known_peers` DB.
+//!
+//! A peer is only worth remembering once it has proven it is on our network by
+//! sending a message bearing our magic bytes; the QUIC handshake proves nothing
+//! on its own, since certificates are not verified.
+
+use std::net::SocketAddr;
+
+use bip300301_enforcer_integration_tests::{
+    integration_test::{activate_sidechain, fund_enforcer, propose_sidechain},
+    setup::{
+        Mode, Network, PostSetup as EnforcerPostSetup,
+        PreSetup as EnforcerPreSetup, SetupOpts as EnforcerSetupOpts,
+        Sidechain as _,
+    },
+    util::{AbortOnDrop, AsyncTrial, TestFailureCollector, TestFileRegistry},
+};
+use futures::{FutureExt, StreamExt as _, channel::mpsc, future::BoxFuture};
+use thunder_app_rpc_api::node::{PrivateRpcClient as _, RpcClient as _};
+use tokio::time::{Duration, sleep};
+use tracing::Instrument as _;
+
+use crate::{
+    setup::{Init, PostSetup},
+    util::BinPaths,
+};
+
+/// Upper bound on any single wait below. Generous, since it is only reached
+/// when something is actually broken.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Addresses currently held in the node's active peer set.
+async fn peer_addrs(node: &PostSetup) -> anyhow::Result<Vec<SocketAddr>> {
+    let peers = node
+        .rpc_client
+        .list_peers()
+        .await?
+        .iter()
+        .map(|peer| peer.address)
+        .collect();
+    Ok(peers)
+}
+
+/// Poll `node`'s active peer set until `addr` is present or absent, as asked.
+///
+/// Waiting on the condition itself keeps the tests fast when things go well,
+/// and makes them fail naming what was awaited rather than tripping some
+/// downstream assertion when they do not.
+async fn wait_for_peer_presence(
+    node: &PostSetup,
+    addr: SocketAddr,
+    want_present: bool,
+) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let addrs = peer_addrs(node).await?;
+        if addrs.contains(&addr) == want_present {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "timed out after {WAIT_TIMEOUT:?} waiting for {addr} to be \
+             {} the peer set, found {addrs:?}",
+            if want_present { "in" } else { "absent from" },
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_for_peer(
+    node: &PostSetup,
+    addr: SocketAddr,
+) -> anyhow::Result<()> {
+    wait_for_peer_presence(node, addr, true).await
+}
+
+async fn wait_for_no_peer(
+    node: &PostSetup,
+    addr: SocketAddr,
+) -> anyhow::Result<()> {
+    wait_for_peer_presence(node, addr, false).await
+}
+
+/// Poll the node's stdout log until a line containing all of `needles`
+/// appears, for at most `timeout`.
+///
+/// Only for states no RPC reports; `list_peers` answers the question wherever
+/// it can.
+async fn wait_for_log(
+    node: &PostSetup,
+    what: &str,
+    needles: &[&str],
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let path = node.thunder_app.data_dir.join("stdout.txt");
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                if contents.lines().any(|line| {
+                    needles.iter().all(|needle| line.contains(needle))
+                }) {
+                    return Ok(());
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "timed out after {timeout:?} waiting for {what} in {}",
+            path.display()
+        );
+        sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Two thunder nodes against a single enforcer.
+async fn setup(
+    bin_paths: BinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<(EnforcerPostSetup, PostSetup, PostSetup)> {
+    let enforcer_pre_setup =
+        EnforcerPreSetup::new(&bin_paths.others, Network::Regtest)?;
+    let mut enforcer_post_setup = {
+        let setup_opts: EnforcerSetupOpts = Default::default();
+        enforcer_pre_setup
+            .setup(Mode::Mempool, setup_opts, res_tx.clone())
+            .await?
+    };
+    let peer = PostSetup::setup(
+        Init {
+            thunder_app: bin_paths.thunder()?.clone(),
+            data_dir_suffix: Some("peer".to_owned()),
+        },
+        &enforcer_post_setup,
+        res_tx.clone(),
+    )
+    .await?;
+    let node = PostSetup::setup(
+        Init {
+            thunder_app: bin_paths.thunder()?.clone(),
+            data_dir_suffix: Some("node".to_owned()),
+        },
+        &enforcer_post_setup,
+        res_tx,
+    )
+    .await?;
+    let () = propose_sidechain::<PostSetup>(&mut enforcer_post_setup).await?;
+    let () = activate_sidechain::<PostSetup>(&mut enforcer_post_setup).await?;
+    let () = fund_enforcer::<PostSetup>(&mut enforcer_post_setup).await?;
+    Ok((enforcer_post_setup, peer, node))
+}
+
+/// A peer that completes a handshake is remembered across a restart; one that
+/// never answers is not. Both are checked against the same restart, so the
+/// unreachable one is held to the same bar as the reachable one.
+async fn peer_persistence_task(
+    bin_paths: BinPaths,
+    res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+) -> anyhow::Result<()> {
+    let (enforcer_post_setup, peer, mut node) =
+        setup(bin_paths, res_tx.clone()).await?;
+    let peer_addr: SocketAddr = peer.net_addr().into();
+
+    // Loopback with nothing bound. Reserved so nothing else can answer.
+    let unreachable_port = reserve_port::ReservedPort::random()?;
+    let unreachable_addr: SocketAddr = std::net::SocketAddrV4::new(
+        std::net::Ipv4Addr::LOCALHOST,
+        unreachable_port.port(),
+    )
+    .into();
+    anyhow::ensure!(
+        peer_addr != unreachable_addr,
+        "unreachable address must not collide with the live peer"
+    );
+
+    tracing::info!(%peer_addr, %unreachable_addr, "Connecting to both peers");
+    // Not an error: the dial only fails later, when the handshake times out.
+    let () = node.rpc_client.connect_peer(unreachable_addr).await?;
+    let () = node.rpc_client.connect_peer(peer_addr).await?;
+
+    // Both are in the active set, having both been dialed -- which is why the
+    // restart below, not this, is the real check. Wait for the live peer to be
+    // validated, since that, not the dial, is what writes it to `known_peers`;
+    // killing the node any earlier would race that write. No RPC reports it.
+    let () = wait_for_log(
+        &node,
+        &format!("{peer_addr} to be validated"),
+        &["peer validated", &peer_addr.to_string()],
+        WAIT_TIMEOUT,
+    )
+    .await?;
+    let () = wait_for_peer(&node, peer_addr).await?;
+
+    // Let the peer notice before bringing the node back: until its heartbeat
+    // times out it refuses the reconnection as a duplicate, which a startup
+    // dial does not retry. Orthogonal to what is under test.
+    tracing::info!("Restarting node");
+    let () = node.kill();
+    let node_addr: SocketAddr = node.net_addr().into();
+    let () = wait_for_no_peer(&peer, node_addr).await?;
+    let () = node.start(res_tx).await?;
+
+    // Validated before the restart, so written to `known_peers` and re-dialed.
+    let () = wait_for_peer(&node, peer_addr).await?;
+    let addrs = peer_addrs(&node).await?;
+    // Never sent a message, so never validated, so never persisted. Both dials
+    // are issued by `Net::new` before the RPC server answers, so had it been
+    // persisted it would already be listed alongside the live peer.
+    anyhow::ensure!(
+        !addrs.contains(&unreachable_addr),
+        "unreachable peer at {unreachable_addr} was never validated and must \
+         not survive a restart, found {addrs:?}"
+    );
+
+    drop(node);
+    drop(peer);
+    drop(unreachable_port);
+    tracing::info!(
+        "Removing {}",
+        enforcer_post_setup.directories.base_dir.path().display()
+    );
+    drop(enforcer_post_setup.tasks);
+    // Wait for tasks to die
+    sleep(Duration::from_secs(1)).await;
+    enforcer_post_setup.directories.base_dir.cleanup()?;
+    Ok(())
+}
+
+async fn peer_persistence(bin_paths: BinPaths) -> anyhow::Result<()> {
+    let (res_tx, mut res_rx) = mpsc::unbounded();
+    let _test_task: AbortOnDrop<()> = tokio::task::spawn({
+        let res_tx = res_tx.clone();
+        async move {
+            let res = peer_persistence_task(bin_paths, res_tx.clone()).await;
+            let _send_err: Result<(), _> = res_tx.unbounded_send(res);
+        }
+        .in_current_span()
+    })
+    .into();
+    res_rx.next().await.ok_or_else(|| {
+        anyhow::anyhow!("Unexpected end of test result stream")
+    })?
+}
+
+pub fn peer_persistence_trial(
+    bin_paths: BinPaths,
+    file_registry: TestFileRegistry,
+    failure_collector: TestFailureCollector,
+) -> AsyncTrial<BoxFuture<'static, anyhow::Result<()>>> {
+    AsyncTrial::new(
+        "peer_persistence",
+        peer_persistence(bin_paths).boxed(),
+        file_registry,
+        failure_collector,
+    )
+}

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -58,6 +58,16 @@ pub enum SetupError {
 }
 
 #[derive(Debug, Error)]
+pub enum RestartError {
+    #[error("Restarted thunder_app did not serve RPC within {timeout:?}")]
+    Timeout {
+        timeout: Duration,
+        #[source]
+        source: Option<jsonrpsee::core::ClientError>,
+    },
+}
+
+#[derive(Debug, Error)]
 pub enum ConfirmDepositError {
     #[error(transparent)]
     Bmm(#[from] BmmError),
@@ -81,7 +91,9 @@ pub enum CreateWithdrawalError {
 pub struct PostSetup {
     // MUST occur before temp dirs and reserved ports in order to ensure that processes are dropped
     // before reserved ports are freed and temp dirs are cleared
-    pub _thunder_app_task: AbortOnDrop<()>,
+    pub _thunder_app_task: Option<AbortOnDrop<()>>,
+    /// Retained so the node can be restarted against the same dir and ports.
+    pub thunder_app: ThunderApp,
     /// RPC client for thunder_app
     pub rpc_client: jsonrpsee::http_client::HttpClient,
     /// Address for receiving deposits
@@ -130,6 +142,52 @@ impl PostSetup {
 
     pub fn net_addr(&self) -> SocketAddrV4 {
         SocketAddrV4::new(Ipv4Addr::LOCALHOST, self.net_port())
+    }
+
+    /// Kill the running `thunder_app`, leaving the data dir intact.
+    ///
+    /// Separate from [`Self::start`] so a test can wait in between: a peer does
+    /// not notice this node died until its heartbeat times out, and until then
+    /// refuses reconnections as duplicates.
+    pub fn kill(&mut self) {
+        self._thunder_app_task = None;
+    }
+
+    /// Spawn `thunder_app` against the existing data dir and ports, and wait
+    /// for it to serve RPC. Any previous process must already have been killed.
+    ///
+    /// Peers that survive a kill/start cycle are exactly those written to
+    /// `known_peers`.
+    pub async fn start(
+        &mut self,
+        res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
+    ) -> Result<(), RestartError> {
+        let thunder_app_task = self
+            .thunder_app
+            .spawn_command_with_args::<String, String, _, _, _>([], [], {
+                move |err| {
+                    let _err: Result<(), _> = res_tx.unbounded_send(Err(err));
+                }
+            });
+        self._thunder_app_task = Some(thunder_app_task);
+        // Polled rather than slept, so the test does not race a slow startup.
+        const RESTART_TIMEOUT: Duration = Duration::from_secs(60);
+        const POLL_INTERVAL: Duration = Duration::from_millis(250);
+        let deadline = tokio::time::Instant::now() + RESTART_TIMEOUT;
+        let mut last_err = None;
+        while tokio::time::Instant::now() < deadline {
+            match self.rpc_client.getblockcount().await {
+                Ok(_) => return Ok(()),
+                Err(err) => {
+                    last_err = Some(err);
+                    sleep(POLL_INTERVAL).await;
+                }
+            }
+        }
+        Err(RestartError::Timeout {
+            timeout: RESTART_TIMEOUT,
+            source: last_err,
+        })
     }
 }
 
@@ -188,7 +246,8 @@ impl Sidechain for PostSetup {
         tracing::debug!("Generating deposit address");
         let deposit_address = rpc_client.get_new_address().await?;
         Ok(Self {
-            _thunder_app_task: thunder_app_task,
+            _thunder_app_task: Some(thunder_app_task),
+            thunder_app,
             rpc_client,
             deposit_address,
             reserved_ports,

--- a/integration_tests/setup.rs
+++ b/integration_tests/setup.rs
@@ -37,6 +37,36 @@ impl ReservedPorts {
 pub struct Init {
     pub thunder_app: PathBuf,
     pub data_dir_suffix: Option<String>,
+    /// Host to bind the P2P endpoint to. IPv6 hosts must be bracketed, as in
+    /// `[::]`.
+    pub net_host: String,
+    /// Applied on every start, including restarts.
+    pub extra_args: Vec<String>,
+}
+
+impl Init {
+    pub fn new(thunder_app: PathBuf, data_dir_suffix: Option<&str>) -> Self {
+        Self {
+            thunder_app,
+            data_dir_suffix: data_dir_suffix.map(ToOwned::to_owned),
+            net_host: Ipv4Addr::LOCALHOST.to_string(),
+            extra_args: Vec::new(),
+        }
+    }
+
+    pub fn with_net_host(mut self, net_host: &str) -> Self {
+        self.net_host = net_host.to_owned();
+        self
+    }
+
+    pub fn with_extra_args<Arg, Args>(mut self, args: Args) -> Self
+    where
+        Arg: Into<String>,
+        Args: IntoIterator<Item = Arg>,
+    {
+        self.extra_args = args.into_iter().map(Into::into).collect();
+        self
+    }
 }
 
 #[derive(Debug, Error)]
@@ -94,6 +124,8 @@ pub struct PostSetup {
     pub _thunder_app_task: Option<AbortOnDrop<()>>,
     /// Retained so the node can be restarted against the same dir and ports.
     pub thunder_app: ThunderApp,
+    /// Reapplied on restart, so it is configured identically.
+    pub extra_args: Vec<String>,
     /// RPC client for thunder_app
     pub rpc_client: jsonrpsee::http_client::HttpClient,
     /// Address for receiving deposits
@@ -164,11 +196,16 @@ impl PostSetup {
     ) -> Result<(), RestartError> {
         let thunder_app_task = self
             .thunder_app
-            .spawn_command_with_args::<String, String, _, _, _>([], [], {
-                move |err| {
-                    let _err: Result<(), _> = res_tx.unbounded_send(Err(err));
-                }
-            });
+            .spawn_command_with_args::<String, String, _, _, _>(
+                [],
+                self.extra_args.clone(),
+                {
+                    move |err| {
+                        let _err: Result<(), _> =
+                            res_tx.unbounded_send(Err(err));
+                    }
+                },
+            );
         self._thunder_app_task = Some(thunder_app_task);
         // Polled rather than slept, so the test does not race a slow startup.
         const RESTART_TIMEOUT: Duration = Duration::from_secs(60);
@@ -224,17 +261,24 @@ impl Sidechain for PostSetup {
                 .reserved_ports
                 .enforcer_serve_grpc
                 .port(),
+            net_host: init.net_host,
             net_port: reserved_ports.net.port(),
             network: Network::Regtest,
             rpc_port: reserved_ports.rpc.port(),
         };
+        let extra_args = init.extra_args;
         let thunder_app_task = thunder_app
-            .spawn_command_with_args::<String, String, _, _, _>([], [], {
-                let res_tx = res_tx.clone();
-                move |err| {
-                    let _err: Result<(), _> = res_tx.unbounded_send(Err(err));
-                }
-            });
+            .spawn_command_with_args::<String, String, _, _, _>(
+                [],
+                extra_args.clone(),
+                {
+                    let res_tx = res_tx.clone();
+                    move |err| {
+                        let _err: Result<(), _> =
+                            res_tx.unbounded_send(Err(err));
+                    }
+                },
+            );
         tracing::debug!("Started thunder");
         sleep(Duration::from_secs(1)).await;
         let rpc_client = jsonrpsee::http_client::HttpClient::builder()
@@ -248,6 +292,7 @@ impl Sidechain for PostSetup {
         Ok(Self {
             _thunder_app_task: Some(thunder_app_task),
             thunder_app,
+            extra_args,
             rpc_client,
             deposit_address,
             reserved_ports,

--- a/integration_tests/unknown_withdrawal.rs
+++ b/integration_tests/unknown_withdrawal.rs
@@ -61,10 +61,7 @@ async fn unknown_withdrawal_task(
     let mut enforcer_post_setup =
         setup(&bin_paths.others, res_tx.clone()).await?;
     let mut sidechain_withdrawer = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("withdrawer".to_owned()),
-        },
+        Init::new(bin_paths.thunder()?.clone(), Some("withdrawer")),
         &enforcer_post_setup,
         res_tx.clone(),
     )
@@ -92,10 +89,7 @@ async fn unknown_withdrawal_task(
     tracing::info!("Withdrawal succeeded");
     // New sidechain node, starting from scratch
     let mut sidechain_successor = PostSetup::setup(
-        Init {
-            thunder_app: bin_paths.thunder()?.clone(),
-            data_dir_suffix: Some("successor".to_owned()),
-        },
+        Init::new(bin_paths.thunder()?.clone(), Some("successor")),
         &enforcer_post_setup,
         res_tx,
     )

--- a/integration_tests/util.rs
+++ b/integration_tests/util.rs
@@ -28,6 +28,9 @@ pub struct ThunderApp {
     pub data_dir: PathBuf,
     pub log_level: Option<tracing::Level>,
     pub mainchain_grpc_port: u16,
+    /// Host to bind the P2P endpoint to. IPv6 hosts must be bracketed, as in
+    /// `[::]`.
+    pub net_host: String,
     /// Port to use for P2P networking
     pub net_port: u16,
     pub network: Network,
@@ -56,7 +59,7 @@ impl ThunderApp {
             "--mainchain-grpc-url".to_owned(),
             format!("http://127.0.0.1:{}", self.mainchain_grpc_port),
             "--net-addr".to_owned(),
-            format!("127.0.0.1:{}", self.net_port),
+            format!("{}:{}", self.net_host, self.net_port),
             format!("--network={}", self.network),
             "--private-rpc-addr".to_owned(),
             format!("127.0.0.1:{}", self.rpc_port),

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -45,13 +45,14 @@ sneed = { workspace = true, features = ["observe"] }
 thiserror = { workspace = true }
 thunder_types = { path = "../types", features = ["heed"] }
 tiny-bip39 = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "sync"] }
 tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 tracing = { workspace = true }
 transitive = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/lib/net/error.rs
+++ b/lib/net/error.rs
@@ -11,6 +11,26 @@ use crate::net::PeerConnectionError;
 #[error("already connected to peer at {0}")]
 pub struct AlreadyConnected(pub SocketAddr);
 
+/// Failure to parse a [`crate::net::PeerAddress`] from `host:port`
+#[derive(Debug, Error)]
+#[error(
+    "peer address `{input}` {reason}, expected `host:port`, \
+     e.g. `seed.example.com:4009` or `[::1]:4009`"
+)]
+pub struct ParsePeerAddress {
+    input: String,
+    reason: &'static str,
+}
+
+impl ParsePeerAddress {
+    pub(crate) fn new(input: &str, reason: &'static str) -> Self {
+        Self {
+            input: input.to_owned(),
+            reason,
+        }
+    }
+}
+
 /// Another connection can be accepted after a non-fatal error
 #[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Fatality, Split, Transitive)]

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -158,33 +158,125 @@ pub fn make_server_endpoint(
 pub type PeerInfoRx =
     mpsc::UnboundedReceiver<(SocketAddr, Option<PeerConnectionInfo>)>;
 
-const SIGNET_SEED_NODE_ADDRS: &[SocketAddr] = {
-    const SIGNET_MINING_SERVER: SocketAddr = SocketAddr::new(
-        std::net::IpAddr::V4(std::net::Ipv4Addr::new(172, 105, 148, 135)),
-        4000 + THIS_SIDECHAIN as u16,
-    );
-    // thunder.bip300.xyz
-    const BIP300_XYZ: SocketAddr = SocketAddr::new(
-        std::net::IpAddr::V4(std::net::Ipv4Addr::new(95, 217, 243, 12)),
-        4000 + THIS_SIDECHAIN as u16,
-    );
-    &[SIGNET_MINING_SERVER, BIP300_XYZ]
-};
+const DEFAULT_SEED_NODE_PORT: u16 = 4000 + THIS_SIDECHAIN as u16;
 
-const FORKNET_SEED_NODE_ADDRS: &[SocketAddr] = {
-    // explorer.bip300.xyz
-    const BIP300_XYZ: SocketAddr = SocketAddr::new(
-        std::net::IpAddr::V4(std::net::Ipv4Addr::new(157, 180, 8, 224)),
-        4000 + THIS_SIDECHAIN as u16,
-    );
-    &[BIP300_XYZ]
-};
+const SIGNET_SEED_NODES: &[(&str, u16)] = &[
+    // Signet mining server.
+    ("172.105.148.135", DEFAULT_SEED_NODE_PORT),
+];
 
-const fn seed_node_addrs(network: Network) -> &'static [SocketAddr] {
-    match network {
-        Network::Signet => SIGNET_SEED_NODE_ADDRS,
+const FORKNET_SEED_NODES: &[(&str, u16)] = &[
+    ("157.180.8.224", DEFAULT_SEED_NODE_PORT),
+    ("explorer.bip300.xyz", DEFAULT_SEED_NODE_PORT),
+];
+
+/// Built-in seed peers for the provided network.
+pub fn builtin_seed_peers(network: Network) -> Vec<PeerAddress> {
+    let seeds: &[(&str, u16)] = match network {
+        Network::Signet => SIGNET_SEED_NODES,
         Network::Regtest => &[],
-        Network::Forknet => FORKNET_SEED_NODE_ADDRS,
+        Network::Forknet => FORKNET_SEED_NODES,
+    };
+    seeds
+        .iter()
+        .map(|(host, port)| PeerAddress {
+            host: url::Host::parse(host)
+                .expect("builtin seed host should parse"),
+            port: *port,
+        })
+        .collect()
+}
+
+/// A peer's address, as a host and port. The host is kept unresolved, so
+/// that a peer whose name resolves to several socket addresses is still
+/// identified (and persisted) as a single peer. Resolution happens when the
+/// peer is dialed.
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize,
+)]
+pub struct PeerAddress {
+    pub host: url::Host,
+    pub port: u16,
+}
+
+impl PeerAddress {
+    /// Resolve to socket addresses. IP hosts resolve to themselves without
+    /// a lookup. Failures are logged and yield no addresses, so a peer that
+    /// cannot be resolved never prevents others from being dialed.
+    pub async fn resolve(&self) -> Vec<SocketAddr> {
+        let domain = match &self.host {
+            url::Host::Ipv4(ipv4) => {
+                return vec![SocketAddr::from((*ipv4, self.port))];
+            }
+            url::Host::Ipv6(ipv6) => {
+                return vec![SocketAddr::from((*ipv6, self.port))];
+            }
+            url::Host::Domain(domain) => domain,
+        };
+        match tokio::net::lookup_host((domain.as_str(), self.port)).await {
+            Ok(socket_addrs) => {
+                let socket_addrs: Vec<SocketAddr> = socket_addrs.collect();
+                if socket_addrs.is_empty() {
+                    tracing::warn!(
+                        peer_address = %self,
+                        "resolve peer: host resolved to no addresses"
+                    );
+                } else {
+                    tracing::debug!(
+                        peer_address = %self,
+                        "resolve peer: resolved host to {socket_addrs:?}"
+                    );
+                }
+                socket_addrs
+            }
+            Err(err) => {
+                tracing::warn!(
+                    peer_address = %self,
+                    "resolve peer: failed to resolve host: {err:#}"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+impl From<SocketAddr> for PeerAddress {
+    fn from(socket_addr: SocketAddr) -> Self {
+        let host = match socket_addr.ip() {
+            std::net::IpAddr::V4(ipv4) => url::Host::Ipv4(ipv4),
+            std::net::IpAddr::V6(ipv6) => url::Host::Ipv6(ipv6),
+        };
+        Self {
+            host,
+            port: socket_addr.port(),
+        }
+    }
+}
+
+impl std::fmt::Display for PeerAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `url::Host` displays IPv6 addresses bracketed, so this
+        // round-trips through the `FromStr` impl.
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+/// Parses `host:port`. IPv6 literals must be bracketed, as in `[::1]:4009`, so
+/// their colons are not read as the port separator.
+impl std::str::FromStr for PeerAddress {
+    type Err = error::ParsePeerAddress;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (host, port) = s
+            .rsplit_once(':')
+            .ok_or_else(|| error::ParsePeerAddress::new(s, "has no port"))?;
+        let host = url::Host::parse(host).map_err(|_| {
+            error::ParsePeerAddress::new(s, "has an invalid host")
+        })?;
+        let port = port.parse().map_err(|_| {
+            error::ParsePeerAddress::new(s, "has an invalid port")
+        })?;
+        Ok(Self { host, port })
     }
 }
 
@@ -208,7 +300,7 @@ pub struct Net {
     // None indicates that the stream has ended
     peer_info_tx:
         mpsc::UnboundedSender<(SocketAddr, Option<PeerConnectionInfo>)>,
-    known_peers: DatabaseUnique<SerdeBincode<SocketAddr>, Unit>,
+    known_peers: DatabaseUnique<SerdeBincode<PeerAddress>, Unit>,
     _version: DatabaseUnique<UnitKey, SerdeBincode<Version>>,
 }
 
@@ -326,10 +418,10 @@ impl Net {
     pub fn remember_peer(
         &self,
         rwtxn: &mut RwTxn,
-        addr: &SocketAddr,
+        peer_address: &PeerAddress,
     ) -> Result<(), Error> {
         self.known_peers
-            .put(rwtxn, addr, &())
+            .put(rwtxn, peer_address, &())
             .map_err(|err| DbError::from(err).into())
     }
 
@@ -338,13 +430,53 @@ impl Net {
     pub fn forget_peer(
         &self,
         rwtxn: &mut RwTxn,
-        addr: &SocketAddr,
+        peer_address: &PeerAddress,
     ) -> Result<bool, Error> {
         self.known_peers
-            .delete(rwtxn, addr)
+            .delete(rwtxn, peer_address)
             .map_err(|err| DbError::from(err).into())
     }
 
+    /// All peers recorded in `known_peers`, to be dialed on startup.
+    ///
+    /// If the records cannot be read -- e.g. they were written by an older
+    /// version, which stored socket addresses -- the DB is cleared instead.
+    /// It is only a cache of validated peers, which will be re-learned.
+    pub fn get_known_peers(
+        &self,
+        env: &sneed::Env<heed::WithoutTls>,
+    ) -> Result<Vec<PeerAddress>, Error> {
+        let known_peers: Result<Vec<(PeerAddress, ())>, DbError> = {
+            let rotxn = env.read_txn().map_err(EnvError::from)?;
+            self.known_peers
+                .iter(&rotxn)
+                .map_err(DbError::from)
+                .and_then(|it| it.collect().map_err(DbError::from))
+        };
+        match known_peers {
+            Ok(known_peers) => Ok(known_peers
+                .into_iter()
+                .map(|(peer_address, ())| peer_address)
+                .collect()),
+            Err(err) => {
+                tracing::warn!(
+                    "clearing unreadable known peers DB: {:#}",
+                    ErrorChain::new(&err)
+                );
+                let mut rwtxn = env.write_txn().map_err(EnvError::from)?;
+                let () = self
+                    .known_peers
+                    .clear(&mut rwtxn)
+                    .map_err(DbError::from)?;
+                rwtxn.commit().map_err(RwTxnError::from)?;
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    /// Known peers and seed nodes are not dialed here: the net task reads
+    /// them via [`Self::get_known_peers`], resolves them, and dials them, so
+    /// that node startup never waits on a resolver.
     pub fn new(
         env: &sneed::Env<heed::WithoutTls>,
         archive: Archive,
@@ -356,17 +488,12 @@ impl Net {
         let (server, _) = make_server_endpoint(bind_addr)?;
         let active_peers = Arc::new(RwLock::new(HashMap::new()));
         let mut rwtxn = env.write_txn()?;
+        // Seed nodes are resolved and dialed on every startup instead of being
+        // written here, so a relocated seed is picked up from DNS.
         let known_peers =
             match DatabaseUnique::open(env, &rwtxn, "known_peers")? {
                 Some(known_peers) => known_peers,
-                None => {
-                    let known_peers =
-                        DatabaseUnique::create(env, &mut rwtxn, "known_peers")?;
-                    for seed_node_addr in seed_node_addrs(network) {
-                        known_peers.put(&mut rwtxn, seed_node_addr, &())?;
-                    }
-                    known_peers
-                }
+                None => DatabaseUnique::create(env, &mut rwtxn, "known_peers")?,
             };
         let version = DatabaseUnique::create(env, &mut rwtxn, "net_version")?;
         if version.try_get(&rwtxn, &())?.is_none() {
@@ -386,45 +513,6 @@ impl Net {
             known_peers,
             _version: version,
         };
-        #[allow(clippy::let_and_return)]
-        let known_peers: Vec<_> = {
-            let rotxn = env.read_txn().map_err(EnvError::from)?;
-            let known_peers = net
-                .known_peers
-                .iter(&rotxn)
-                .map_err(DbError::from)?
-                .collect()
-                .map_err(DbError::from)?;
-            known_peers
-        };
-        let () = known_peers.into_iter().try_for_each(|(peer_addr, _)| {
-            tracing::trace!(
-                "new net: connecting to already known peer at {peer_addr}"
-            );
-            match net.connect_peer(env.clone(), peer_addr) {
-                Err(Error::Connect(
-                    quinn::ConnectError::InvalidRemoteAddress(addr),
-                )) => {
-                    tracing::warn!(
-                        %addr, "new net: known peer with invalid remote address, removing"
-                    );
-                    let mut rwtxn = env.write_txn()?;
-                    net.known_peers.delete(&mut rwtxn, &peer_addr).map_err(DbError::from)?;
-                    rwtxn.commit()?;
-                    tracing::info!(
-                        %addr,
-                        "new net: removed known peer with invalid remote address"
-                    );
-                    Ok(())
-                }
-                res => res,
-            }
-        })
-        // TODO: would be better to indicate this in the return error? tbh I want to scrap
-        // the typed error out of here, and just use anyhow
-        .inspect_err(|err| {
-            tracing::error!("unable to connect to known peers during net construction: {err:#}");
-        })?;
         Ok((net, peer_info_rx))
     }
 

--- a/lib/net/mod.rs
+++ b/lib/net/mod.rs
@@ -270,6 +270,8 @@ impl Net {
             .collect()
     }
 
+    /// The peer is not recorded in `known_peers` here, see
+    /// [`Self::remember_peer`].
     #[instrument(skip_all, fields(addr), err(Debug))]
     pub fn connect_peer(
         &self,
@@ -289,11 +291,6 @@ impl Net {
             return Err(Error::UnspecfiedPeerIP(addr.ip()));
         }
         let connecting = self.server.connect(addr, "localhost")?;
-        let mut rwtxn = env.write_txn().map_err(EnvError::from)?;
-        self.known_peers
-            .put(&mut rwtxn, &addr, &())
-            .map_err(DbError::from)?;
-        rwtxn.commit().map_err(RwTxnError::from)?;
         let connection_ctxt = PeerConnectionCtxt {
             env,
             archive: self.archive.clone(),
@@ -318,6 +315,22 @@ impl Net {
         tracing::trace!("connect peer: adding to active peers");
         self.add_active_peer(addr, connection_handle)?;
         Ok(())
+    }
+
+    /// Record a peer in `known_peers`, so that it is dialed again on the next
+    /// startup.
+    ///
+    /// Only for peers that have emitted [`PeerConnectionInfo::Validated`].
+    /// Recording one any earlier persists nodes from other networks, which are
+    /// then re-dialed on every startup forever.
+    pub fn remember_peer(
+        &self,
+        rwtxn: &mut RwTxn,
+        addr: &SocketAddr,
+    ) -> Result<(), Error> {
+        self.known_peers
+            .put(rwtxn, addr, &())
+            .map_err(|err| DbError::from(err).into())
     }
 
     /// Delete peer from known_peers DB.
@@ -461,13 +474,8 @@ impl Net {
             return Ok(None);
         }
         tracing::info!(%addr, "connected to new peer");
-        let mut rwtxn = env.write_txn().map_err(EnvError::from)?;
-        self.known_peers
-            .put(&mut rwtxn, &addr, &())
-            .map_err(DbError::from)?;
-        rwtxn.commit().map_err(RwTxnError::from)?;
-
-        tracing::trace!(%addr, "wrote peer to database");
+        // Not written to `known_peers` here: the handshake proves nothing about
+        // which network the peer is on. Recorded once it emits `Validated`.
         let connection_ctxt = PeerConnectionCtxt {
             env,
             archive: self.archive.clone(),

--- a/lib/net/peer/mod.rs
+++ b/lib/net/peer/mod.rs
@@ -119,6 +119,9 @@ pub enum Info {
     NewTipReady(Tip),
     NewTransaction(AuthorizedTransaction),
     Response(Box<(ResponseMessage, Request)>),
+    /// The peer has sent a message bearing our magic bytes, confirming it is on
+    /// the same network. Emitted at most once per connection.
+    Validated,
 }
 
 impl From<ConnectionError> for Info {

--- a/lib/net/peer/task.rs
+++ b/lib/net/peer/task.rs
@@ -831,10 +831,24 @@ impl ConnectionTask {
         let mut peer_state = Option::<PeerStateId>::None;
         // known peer states
         let mut peer_states = HashMap::<PeerStateId, PeerState>::new();
+        let mut sent_validated = false;
         let mut mailbox_stream = self
             .mailbox_rx
             .into_stream(self.connection, &self.received_msg_successfully);
         while let Some(mailbox_item) = mailbox_stream.next().await {
+            // The mailbox stream sets `received_msg_successfully` once a
+            // message bearing our magic bytes has been received; forward
+            // that edge to the net task once, so it can persist the peer.
+            if !sent_validated
+                && self
+                    .received_msg_successfully
+                    .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                sent_validated = true;
+                if self.info_tx.unbounded_send(Info::Validated).is_err() {
+                    tracing::error!("Failed to send validated info")
+                }
+            }
             match mailbox_item {
                 MailboxItem::Error(err) => return Err(err.into()),
                 MailboxItem::InternalMessage(msg) => {

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -36,6 +36,14 @@ use mainchain_task::MainchainTaskHandle;
 mod net_task;
 use net_task::NetTaskHandle;
 
+#[derive(Clone, Debug)]
+pub struct Config<'a> {
+    pub datadir: &'a Path,
+    pub bind_addr: SocketAddr,
+    pub magic_bytes_override: Option<crate::net::peer_message::MagicBytes>,
+    pub network: Network,
+}
+
 #[derive(Clone)]
 pub struct Node<MainchainTransport = Channel> {
     archive: Archive,
@@ -55,14 +63,11 @@ where
     MainchainTransport: proto::Transport,
 {
     pub fn new(
-        datadir: &Path,
-        bind_addr: SocketAddr,
+        config: Config<'_>,
         cusf_mainchain: mainchain::ValidatorClient<MainchainTransport>,
         cusf_mainchain_wallet: Option<
             mainchain::WalletClient<MainchainTransport>,
         >,
-        magic_bytes_override: Option<crate::net::peer_message::MagicBytes>,
-        network: Network,
         runtime: &tokio::runtime::Runtime,
     ) -> Result<Self, Error>
     where
@@ -72,6 +77,12 @@ where
             tonic::body::Body,
         >>::Future: Send,
 {
+        let Config {
+            datadir,
+            bind_addr,
+            magic_bytes_override,
+            network,
+        } = config;
         let env_path = datadir.join("data.mdb");
         // let _ = std::fs::remove_dir_all(&env_path);
         std::fs::create_dir_all(&env_path)?;

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -16,7 +16,7 @@ use tonic::transport::Channel;
 use crate::{
     archive::Archive,
     mempool::{self, MemPool},
-    net::Net,
+    net::{Net, PeerAddress},
     state::State,
     types::{
         Accumulator, Address, AmountOverflowError, AmountUnderflowError,
@@ -42,6 +42,7 @@ pub struct Config<'a> {
     pub bind_addr: SocketAddr,
     pub magic_bytes_override: Option<crate::net::peer_message::MagicBytes>,
     pub network: Network,
+    pub seed_nodes: &'a [crate::net::PeerAddress],
 }
 
 #[derive(Clone)]
@@ -82,6 +83,7 @@ where
             bind_addr,
             magic_bytes_override,
             network,
+            seed_nodes,
         } = config;
         let env_path = datadir.join("data.mdb");
         // let _ = std::fs::remove_dir_all(&env_path);
@@ -140,6 +142,11 @@ where
             bind_addr,
         )?;
 
+        let seed_peers: Vec<crate::net::PeerAddress> =
+            crate::net::builtin_seed_peers(network)
+                .into_iter()
+                .chain(seed_nodes.iter().cloned())
+                .collect();
         let net_task = NetTaskHandle::new(
             runtime,
             env.clone(),
@@ -149,6 +156,7 @@ where
             mempool.clone(),
             net.clone(),
             peer_info_rx,
+            seed_peers,
             state.clone(),
         );
         let cusf_mainchain_wallet =
@@ -535,7 +543,8 @@ where
 
     pub fn forget_peer(&self, addr: &SocketAddr) -> Result<bool, Error> {
         let mut rwtxn = self.env.write_txn().map_err(EnvError::from)?;
-        let res = self.net.forget_peer(&mut rwtxn, addr)?;
+        let peer_address: PeerAddress = (*addr).into();
+        let res = self.net.forget_peer(&mut rwtxn, &peer_address)?;
         rwtxn.commit().map_err(RwTxnError::from)?;
         Ok(res)
     }

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -1113,6 +1113,21 @@ impl NetTask {
                                 .net
                                 .push_tx(HashSet::from_iter([addr]), &new_tx);
                         }
+                        PeerConnectionInfo::Validated => {
+                            tracing::debug!(
+                                %addr, "peer validated, recording in known peers"
+                            );
+                            let mut rwtxn = self
+                                .ctxt
+                                .env
+                                .write_txn()
+                                .map_err(EnvError::from)?;
+                            let () = self
+                                .ctxt
+                                .net
+                                .remember_peer(&mut rwtxn, &addr)?;
+                            rwtxn.commit().map_err(RwTxnError::from)?;
+                        }
                         PeerConnectionInfo::Response(boxed) => {
                             let (resp, req) = *boxed;
                             tracing::trace!(

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque, hash_map},
     net::SocketAddr,
     sync::Arc,
     time::Duration,
@@ -27,7 +27,7 @@ use crate::{
     archive::Archive,
     mempool::MemPool,
     net::{
-        self, Net, PeerConnectionError, PeerConnectionInfo,
+        self, Net, PeerAddress, PeerConnectionError, PeerConnectionInfo,
         PeerConnectionMailboxError, PeerConnectionMessage, PeerInfoRx,
         PeerRequest, PeerResponse, PeerStateId, peer_message,
     },
@@ -441,6 +441,8 @@ struct NetTask {
     /// to reorg to the new tip, on the corresponding oneshot receiver.
     new_tip_ready_tx: UnboundedSender<NewTipReadyMessage>,
     peer_info_rx: PeerInfoRx,
+    /// Seed peers to resolve and dial on startup, alongside the known peers
+    seed_peers: Vec<PeerAddress>,
 }
 
 impl NetTask {
@@ -814,6 +816,58 @@ impl NetTask {
         }
     }
 
+    /// Dial the next untried socket address for an initial peer.
+    ///
+    /// Addresses are tried one at a time, with the untried remainder stored
+    /// in `fallback_addrs`, so that a peer whose host resolves to several
+    /// addresses holds at most one connection.
+    fn dial_next_addr(
+        ctxt: &NetTaskContext,
+        dialed_peers: &mut HashMap<SocketAddr, PeerAddress>,
+        fallback_addrs: &mut HashMap<PeerAddress, VecDeque<SocketAddr>>,
+        peer_address: PeerAddress,
+        mut untried: VecDeque<SocketAddr>,
+    ) {
+        while let Some(socket_addr) = untried.pop_front() {
+            // Several hosts may resolve to one address, dial once
+            let hash_map::Entry::Vacant(dialed_entry) =
+                dialed_peers.entry(socket_addr)
+            else {
+                continue;
+            };
+            dialed_entry.insert(peer_address.clone());
+            match ctxt.net.connect_peer(ctxt.env.clone(), socket_addr) {
+                Ok(()) => {
+                    tracing::info!(
+                        %socket_addr, %peer_address,
+                        "dial peer: connecting"
+                    );
+                    // Also stored when empty, so that exhaustion is logged
+                    // when the last address fails
+                    fallback_addrs.insert(peer_address, untried);
+                    return;
+                }
+                // A connection to this address means a connection to this
+                // peer, so its other addresses must not be dialed
+                Err(net::Error::AlreadyConnected(_)) => {
+                    tracing::debug!(
+                        %socket_addr, %peer_address,
+                        "dial peer: already connected"
+                    );
+                    return;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        %socket_addr, %peer_address,
+                        "dial peer: failed to connect: {:#}",
+                        ErrorChain::new(&err)
+                    );
+                }
+            }
+        }
+        tracing::debug!(%peer_address, "dial peer: no more addresses to try");
+    }
+
     async fn run(self) -> Result<(), Error> {
         tracing::debug!("starting net task");
         #[derive(Debug)]
@@ -837,10 +891,35 @@ impl NetTask {
             // attempting to reorg to the new tip, on the corresponding oneshot
             // receiver.
             NewTipReady(Tip, Option<SocketAddr>, Option<oneshot::Sender<bool>>),
+            // Dial an initial peer, trying its resolved socket addresses
+            // one at a time
+            DialPeer(PeerAddress, Vec<SocketAddr>),
             PeerInfo(Option<(SocketAddr, Option<PeerConnectionInfo>)>),
             // Signal to reconnect to a peer
             ReconnectPeer(SocketAddr),
         }
+        // Peers to dial on startup: those remembered in `known_peers`, and
+        // the seed peers. Hosts are resolved here in the net task, on a
+        // stream merged into the mailbox, so a slow resolver delays nothing
+        // else.
+        let initial_peers: Vec<PeerAddress> = {
+            let known_peers = self.ctxt.net.get_known_peers(&self.ctxt.env)?;
+            let mut seen = HashSet::new();
+            known_peers
+                .into_iter()
+                .chain(self.seed_peers)
+                .filter(|peer_address| seen.insert(peer_address.clone()))
+                .collect()
+        };
+        let dial_initial_peers = stream::iter(initial_peers)
+            .map(|peer_address| async move {
+                let socket_addrs = peer_address.resolve().await;
+                (peer_address, socket_addrs)
+            })
+            .buffer_unordered(8)
+            .map(|(peer_address, socket_addrs)| {
+                MailboxItem::DialPeer(peer_address, socket_addrs)
+            });
         let accept_connections = stream::try_unfold((), |()| {
             let env = self.ctxt.env.clone();
             let net = self.ctxt.net.clone();
@@ -895,6 +974,7 @@ impl NetTask {
             .map(|addr| MailboxItem::ReconnectPeer(addr.unwrap()));
         let mut mailbox_stream = stream::select_all([
             accept_connections.boxed(),
+            dial_initial_peers.boxed(),
             forward_request_stream.boxed(),
             mainchain_task_response_stream.boxed(),
             new_tip_ready_stream.boxed(),
@@ -914,6 +994,15 @@ impl NetTask {
             mainchain_task::Request,
             HashSet<(SocketAddr, PeerStateId)>,
         >::new();
+        // Maps dialed socket addresses to the peer address they resolved
+        // from, so that a validated peer is remembered by host, rather than
+        // by a resolved address that may change
+        let mut dialed_peers = HashMap::<SocketAddr, PeerAddress>::new();
+        // Maps initial peers to their resolved-but-untried socket addresses.
+        // An entry is dropped once a connection to the peer validates, and
+        // advanced when the current attempt's connection closes before that
+        let mut fallback_addrs =
+            HashMap::<PeerAddress, VecDeque<SocketAddr>>::new();
         while let Some(mailbox_item) = mailbox_stream.next().await {
             tracing::trace!(?mailbox_item, "received new mailbox item");
             match mailbox_item {
@@ -936,6 +1025,15 @@ impl NetTask {
                         );
                     }
                 },
+                MailboxItem::DialPeer(peer_address, socket_addrs) => {
+                    let () = Self::dial_next_addr(
+                        &self.ctxt,
+                        &mut dialed_peers,
+                        &mut fallback_addrs,
+                        peer_address,
+                        socket_addrs.into(),
+                    );
+                }
                 MailboxItem::ForwardMainchainTaskRequest(
                     request,
                     peer,
@@ -1027,6 +1125,22 @@ impl NetTask {
                     // peer connection is closed, remove it
                     tracing::warn!(%addr, "Connection to peer closed");
                     let () = self.ctxt.net.remove_active_peer(addr);
+                    // This event fires exactly once per connection, after any
+                    // error. A fallback entry still exists only if no
+                    // connection to the peer has validated, so try its next
+                    // resolved address, if any
+                    if let Some(peer_address) = dialed_peers.get(&addr).cloned()
+                        && let Some(untried) =
+                            fallback_addrs.remove(&peer_address)
+                    {
+                        let () = Self::dial_next_addr(
+                            &self.ctxt,
+                            &mut dialed_peers,
+                            &mut fallback_addrs,
+                            peer_address,
+                            untried,
+                        );
+                    }
                     continue;
                 }
                 MailboxItem::PeerInfo(Some((addr, Some(peer_info)))) => {
@@ -1114,8 +1228,20 @@ impl NetTask {
                                 .push_tx(HashSet::from_iter([addr]), &new_tx);
                         }
                         PeerConnectionInfo::Validated => {
+                            // Remembered under the address it was dialed as,
+                            // so a peer dialed by hostname is re-dialed by
+                            // that hostname
+                            let peer_address = dialed_peers
+                                .get(&addr)
+                                .cloned()
+                                .unwrap_or_else(|| PeerAddress::from(addr));
+                            // The peer is connected, so its other resolved
+                            // addresses must not be dialed
+                            let _untried: Option<VecDeque<SocketAddr>> =
+                                fallback_addrs.remove(&peer_address);
                             tracing::debug!(
-                                %addr, "peer validated, recording in known peers"
+                                %addr, %peer_address,
+                                "peer validated, recording in known peers"
                             );
                             let mut rwtxn = self
                                 .ctxt
@@ -1125,7 +1251,7 @@ impl NetTask {
                             let () = self
                                 .ctxt
                                 .net
-                                .remember_peer(&mut rwtxn, &addr)?;
+                                .remember_peer(&mut rwtxn, &peer_address)?;
                             rwtxn.commit().map_err(RwTxnError::from)?;
                         }
                         PeerConnectionInfo::Response(boxed) => {
@@ -1195,6 +1321,7 @@ impl NetTaskHandle {
         mempool: MemPool,
         net: Net,
         peer_info_rx: PeerInfoRx,
+        seed_peers: Vec<PeerAddress>,
         state: State,
     ) -> Self {
         let ctxt = NetTaskContext {
@@ -1218,6 +1345,7 @@ impl NetTaskHandle {
             new_tip_ready_tx: new_tip_ready_tx.clone(),
             new_tip_ready_rx,
             peer_info_rx,
+            seed_peers,
         };
         let task = runtime.spawn(async {
             if let Err(err) = task.run().await {


### PR DESCRIPTION
Take in seed nodes as host names in addition to raw IP addresses. This
makes it easier to reconfigure seeds without having to release new
Thunder versions. Re-resolve on startup. Expose passing custom seed
nodes via CLI.