### PR TITLE
Adjust `cargo fmt` invocation

### DIFF
--- a/.github/workflows/check_lint_build.yaml
+++ b/.github/workflows/check_lint_build.yaml
@@ -49,7 +49,7 @@ jobs:
           shared-key: debug-x86_64-unknown-linux-gnu
 
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt -- --check
       
       - name: Cargo check
         run: cargo check --all-targets --all-features

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ default:
     @just --list
 
 fmt:
-    cargo fmt --all
+    cargo fmt
 
 build:
     cargo build


### PR DESCRIPTION
The `--all` flag descended into the bip300301_enforcer sub module, which is not what we want.